### PR TITLE
fix(shortcuts): pass number to handle.resize() not String

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -39,7 +39,7 @@ export function useKeyboardShortcuts(): void {
             const handle = panelRefs.get(focusedId);
             if (handle) {
               const pct = handle.getSize().asPercentage;
-              handle.resize(String(Math.min(pct + 5, 95)));
+              handle.resize(Math.min(pct + 5, 95));
             }
           }
         } else if (e.code === "Minus") {
@@ -52,7 +52,7 @@ export function useKeyboardShortcuts(): void {
             const handle = panelRefs.get(focusedId);
             if (handle) {
               const pct = handle.getSize().asPercentage;
-              handle.resize(String(Math.max(pct - 5, 5)));
+              handle.resize(Math.max(pct - 5, 5));
             }
           }
         }


### PR DESCRIPTION
## Summary

- `PanelImperativeHandle.resize()` in `react-resizable-panels` v4 accepts a `number`, not a `string`
- The grow (CMD+Opt+=) and shrink (CMD+Opt+-) keyboard shortcuts were wrapping the percentage value in `String()` before passing it to `handle.resize()`, causing a type mismatch at runtime
- Removed both `String()` wrappers so the numeric result of `Math.min` / `Math.max` is passed directly

## Test plan

- [ ] Open any workspace with two or more panels
- [ ] Focus a panel (click it)
- [ ] Press CMD+Opt+= — panel should grow by 5%
- [ ] Press CMD+Opt+- — panel should shrink by 5%
- [ ] Verify resize works correctly and no console type errors appear

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/90?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->