### PR TITLE
fix(panel): guard onLayoutChanged sizes length before resizeSplit

### DIFF
--- a/src/components/CardTree.tsx
+++ b/src/components/CardTree.tsx
@@ -27,11 +27,13 @@ function CardTree({ nodeId }: Props) {
   return (
     <Group
       orientation={node.direction}
-      onLayoutChanged={(sizes) =>
-        useWorkspaceStore
-          .getState()
-          .resizeSplit(nodeId, sizes as unknown as [number, number])
-      }
+      onLayoutChanged={(sizes) => {
+        if (sizes.length === 2) {
+          useWorkspaceStore
+            .getState()
+            .resizeSplit(nodeId, sizes as [number, number]);
+        }
+      }}
       className="h-full w-full"
     >
       <ResizablePanel


### PR DESCRIPTION
## Summary

- Replace the `sizes as unknown as [number, number]` double cast in `CardTree.tsx` with a runtime `sizes.length === 2` guard before calling `resizeSplit`.
- This prevents silent state corruption if `react-resizable-panels` ever emits an array with a length other than 2.
- The cast is now a safe single cast `sizes as [number, number]` that is only reached when the length is verified.

## Test plan

- [ ] Resize a split panel and confirm sizes persist correctly (no regression)
- [ ] Confirm TypeScript compiles without errors (`npm run typecheck` or `tsc --noEmit`)

Closes #83

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/89?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->