### PR TITLE
fix(api): import ReactNode directly instead of React.ReactNode

### DIFF
--- a/plugins/api/src/context.tsx
+++ b/plugins/api/src/context.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+import type { PluginContext } from "./plugin";
+
+const Context = createContext<PluginContext | null>(null);
+
+export function PluginContextProvider({
+  value,
+  children,
+}: {
+  value: PluginContext;
+  children: ReactNode;
+}) {
+  return <Context value={value}>{children}</Context>;
+}
+
+export function usePluginContext(): PluginContext {
+  const ctx = useContext(Context);
+  if (!ctx) {
+    throw new Error(
+      "usePluginContext must be called inside a plugin rendered by Origin",
+    );
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary

- Replace `React.ReactNode` type annotation with `ReactNode` imported directly from `react`
- Add `import type { ReactNode } from 'react'` to avoid relying on the `React` UMD global namespace

## Problem

`plugins/api/src/context.tsx` used `React.ReactNode` as a type annotation but `React` was not imported — only named exports `createContext` and `useContext` were. This caused a TypeScript error: `'React' refers to a UMD global`.

## Fix

```tsx
import type { ReactNode } from 'react';

// children: ReactNode instead of children: React.ReactNode
```

## Test plan

- [ ] TypeScript compilation passes without errors (`tsc --noEmit`)
- [ ] `PluginContextProvider` renders children correctly at runtime

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/91?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->