### PR TITLE
fix(shortcuts): pass number to handle.resize(), not string

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -39,7 +39,7 @@ export function useKeyboardShortcuts(): void {
             const handle = panelRefs.get(focusedId);
             if (handle) {
               const pct = handle.getSize().asPercentage;
-              handle.resize(String(Math.min(pct + 5, 95)));
+              handle.resize(Math.min(pct + 5, 95));
             }
           }
         } else if (e.code === "Minus") {
@@ -52,7 +52,7 @@ export function useKeyboardShortcuts(): void {
             const handle = panelRefs.get(focusedId);
             if (handle) {
               const pct = handle.getSize().asPercentage;
-              handle.resize(String(Math.max(pct - 5, 5)));
+              handle.resize(Math.max(pct - 5, 5));
             }
           }
         }


### PR DESCRIPTION
## Summary

- Removes two incorrect `String()` wrappers in `src/hooks/useKeyboardShortcuts.ts`
- `PanelImperativeHandle.resize()` (react-resizable-panels v4) accepts a `number`, not a `string`
- Affected shortcuts: CMD+Opt+= (grow panel) and CMD+Opt+- (shrink panel)

## Changes

```ts
// Before (broken)
handle.resize(String(Math.min(pct + 5, 95)));
handle.resize(String(Math.max(pct - 5, 5)));

// After (correct)
handle.resize(Math.min(pct + 5, 95));
handle.resize(Math.max(pct - 5, 5));
```

## Test plan

- [ ] Open a workspace with multiple panels
- [ ] Focus a panel and press CMD+Opt+= — panel should grow by ~5%
- [ ] Press CMD+Opt+- — panel should shrink by ~5%
- [ ] Verify panel size is clamped at 5% (min) and 95% (max)

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/92?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->