### PR TITLE
fix(plugin-host): reset ErrorBoundary on pluginId change

### DIFF
--- a/src/components/PluginHost.tsx
+++ b/src/components/PluginHost.tsx
@@ -48,6 +48,7 @@ function PluginHostInner({ pluginId, context }: Props) {
 export default function PluginHost({ pluginId, context }: Props) {
   return (
     <ErrorBoundary
+      resetKeys={[pluginId]}
       fallbackRender={({ error }) => (
         <div className="flex h-full items-center justify-center p-4 text-sm text-destructive">
           Plugin error: {error instanceof Error ? error.message : String(error)}


### PR DESCRIPTION
## Summary

- Adds `resetKeys={[pluginId]}` to the `<ErrorBoundary>` wrapper in `PluginHost.tsx`
- When a plugin crashes and the user assigns a different plugin to that card, the error boundary is now automatically reset so the new plugin mounts cleanly instead of showing the stale error fallback

## Test plan

- [ ] Assign a plugin to a card and trigger a runtime error (e.g. temporarily break a plugin component) so the error fallback is shown
- [ ] Change the card's plugin to a different (working) plugin via the card header
- [ ] Verify the new plugin mounts and renders correctly instead of showing the error fallback
- [ ] Verify that a working plugin switching to another working plugin still works as before

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/93?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->