### PR TITLE
fix(cardtree): guard onLayoutChanged sizes before resizeSplit

### DIFF
--- a/src/components/CardTree.tsx
+++ b/src/components/CardTree.tsx
@@ -27,11 +27,13 @@ function CardTree({ nodeId }: Props) {
   return (
     <Group
       orientation={node.direction}
-      onLayoutChanged={(sizes) =>
-        useWorkspaceStore
-          .getState()
-          .resizeSplit(nodeId, sizes as unknown as [number, number])
-      }
+      onLayoutChanged={(sizes) => {
+        if (sizes.length === 2) {
+          useWorkspaceStore
+            .getState()
+            .resizeSplit(nodeId, sizes as [number, number]);
+        }
+      }}
       className="h-full w-full"
     >
       <ResizablePanel


### PR DESCRIPTION
## Summary

- Replaces the unsafe `sizes as unknown as [number, number]` double cast in `CardTree.tsx` with a runtime length guard
- `onLayoutChanged` returns `number[]`; the guard ensures `resizeSplit` is only called when the array is exactly two elements, preventing silent state corruption

## Changes

**`src/components/CardTree.tsx`** — `onLayoutChanged` callback now checks `sizes.length === 2` before passing to `useWorkspaceStore.getState().resizeSplit()`.

## Test plan

- [ ] Resize a split panel — layout sizes persist correctly
- [ ] Open, split, and close panels across workspaces — no console errors or corrupted state
- [ ] Verify TypeScript compiles cleanly (`tsc --noEmit`)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/94?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->