### PR TITLE
fix(shortcuts): prevent Tauri listener leak on fast unmount

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -94,17 +94,25 @@ export function useKeyboardShortcuts(): void {
 
     window.addEventListener("keydown", handleKeyDown);
 
-    let unlistenMenu: (() => void) | undefined;
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+
     listen("close-workspace", () => {
       const state = useWorkspaceStore.getState();
       state.closeWorkspace(state.activeWorkspaceId);
     }).then((fn) => {
-      unlistenMenu = fn;
+      if (!cancelled) {
+        unlisten = fn;
+      } else {
+        // Component already unmounted — clean up the listener immediately
+        fn();
+      }
     });
 
     return () => {
+      cancelled = true;
       window.removeEventListener("keydown", handleKeyDown);
-      unlistenMenu?.();
+      unlisten?.();
     };
   }, []);
 }


### PR DESCRIPTION
## Summary

- Fixes a race condition in `useKeyboardShortcuts` where the Tauri `listen('close-workspace')` Promise could resolve _after_ the component unmounted, leaving `unlisten` as `undefined` and the event listener permanently attached.
- Introduces a `cancelled` flag: if the component has already unmounted when the Promise resolves, `fn()` is called immediately to clean up the listener right away instead of leaking it.
- The synchronous cleanup path (`return () => { ... }`) now sets `cancelled = true` first and calls `unlisten?.()` for the normal (non-race) case.

## Test plan

- [ ] Verify that fast mount/unmount cycles (e.g. rapid workspace switches) no longer accumulate stale `close-workspace` listeners.
- [ ] Confirm normal shortcut behaviour (CMD+W, CMD+T, etc.) is unaffected.
- [ ] Check that `close-workspace` from the menu still triggers `closeWorkspace` when the hook is mounted normally.

Closes #78

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/96?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->