### PR TITLE
chore: enable noUncheckedIndexedAccess in tsconfig

### DIFF
--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -94,7 +94,8 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
           if (wasActive) {
             // Prefer previous tab; fall back to the tab now at idx (next)
             const nextIdx = Math.max(0, idx - 1);
-            draft.activeWorkspaceId = draft.workspaces[nextIdx].id;
+            const next = draft.workspaces[nextIdx];
+            if (next) draft.activeWorkspaceId = next.id;
           }
         }),
 
@@ -170,13 +171,13 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
             pluginId: null,
           } satisfies CardLeaf;
 
-          ws.nodes[cardId].parentId = newSplitId;
+          node.parentId = newSplitId;
 
           if (parentId === null) {
             ws.rootId = newSplitId;
           } else {
             const parent = ws.nodes[parentId];
-            if (parent.type === "split") {
+            if (parent && parent.type === "split") {
               const idx = parent.childIds.indexOf(cardId) as 0 | 1;
               parent.childIds[idx] = newSplitId;
             }
@@ -209,13 +210,14 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
           const siblingId = parent.childIds.find((id) => id !== cardId)!;
           const grandParentId = parent.parentId;
 
-          ws.nodes[siblingId].parentId = grandParentId;
+          const sibling = ws.nodes[siblingId];
+          if (sibling) sibling.parentId = grandParentId;
 
           if (grandParentId === null) {
             ws.rootId = siblingId;
           } else {
             const gp = ws.nodes[grandParentId];
-            if (gp.type === "split") {
+            if (gp && gp.type === "split") {
               const idx = gp.childIds.indexOf(parentSplitId) as 0 | 1;
               gp.childIds[idx] = siblingId;
             }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],


### PR DESCRIPTION
## Summary

- Adds `"noUncheckedIndexedAccess": true` to `compilerOptions` in `tsconfig.json`
- Fixes all resulting TypeScript errors in `src/store/workspaceStore.ts` (4 call sites)
- Zero remaining type errors — `npx tsc --noEmit` exits cleanly

## What changed in `workspaceStore.ts`

| Location | Old code | Fix |
|---|---|---|
| `closeWorkspace` (line ~97) | `draft.workspaces[nextIdx].id` | Extract to `const next = draft.workspaces[nextIdx]` and guard with `if (next)` |
| `splitCard` (line ~173) | `ws.nodes[cardId].parentId = newSplitId` | Use the already-validated `node` variable instead of re-indexing |
| `splitCard` (line ~179) | `if (parent.type === "split")` | Add `parent &&` before the type check |
| `closeCard` (line ~212) | `ws.nodes[siblingId].parentId = grandParentId` | Extract to `const sibling = ws.nodes[siblingId]` and guard with `if (sibling)` |
| `closeCard` (line ~218) | `if (gp.type === "split")` | Add `gp &&` before the type check |

All guards are logically unreachable at runtime (the store invariants guarantee these nodes exist at the points they are accessed), but the explicit checks make the code safer and satisfy the stricter compiler flag.

## Test plan

- [x] `npx tsc --noEmit` exits with no errors
- [ ] Manual smoke test: open app, split panels, close panels — verify no regressions

Closes #88

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/99?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->