### PR TITLE
fix(store): guard selectActiveWorkspace and actions against missing workspace

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -16,9 +16,9 @@ interface Props {
 
 function Card({ nodeId }: Props) {
   const isFocused = useWorkspaceStore(
-    (s) => selectActiveWorkspace(s).focusedCardId === nodeId,
+    (s) => selectActiveWorkspace(s)?.focusedCardId === nodeId,
   );
-  const node = useWorkspaceStore((s) => selectActiveWorkspace(s).nodes[nodeId]);
+  const node = useWorkspaceStore((s) => selectActiveWorkspace(s)?.nodes[nodeId]);
   const setFocus = useWorkspaceStore((s) => s.setFocus);
   const closeCard = useWorkspaceStore((s) => s.closeCard);
   const appDataDir = useWorkspaceStore((s) => s.appDataDir);

--- a/src/components/CardLayout.tsx
+++ b/src/components/CardLayout.tsx
@@ -6,9 +6,9 @@ import EmptyState from "./EmptyState";
 import CardTree from "./CardTree";
 
 function CardLayout() {
-  const rootId = useWorkspaceStore((s) => selectActiveWorkspace(s).rootId);
+  const rootId = useWorkspaceStore((s) => selectActiveWorkspace(s)?.rootId);
 
-  if (rootId === null) {
+  if (!rootId) {
     return <EmptyState />;
   }
 

--- a/src/components/CardTree.tsx
+++ b/src/components/CardTree.tsx
@@ -15,7 +15,9 @@ interface Props {
 }
 
 function CardTree({ nodeId }: Props) {
-  const node = useWorkspaceStore((s) => selectActiveWorkspace(s).nodes[nodeId]);
+  const node = useWorkspaceStore(
+    (s) => selectActiveWorkspace(s)?.nodes[nodeId],
+  );
 
   if (!node) return null;
 

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -34,7 +34,7 @@ export function useKeyboardShortcuts(): void {
           e.preventDefault();
           const focusedId = selectActiveWorkspace(
             useWorkspaceStore.getState(),
-          ).focusedCardId;
+          )?.focusedCardId;
           if (focusedId) {
             const handle = panelRefs.get(focusedId);
             if (handle) {
@@ -47,7 +47,7 @@ export function useKeyboardShortcuts(): void {
           e.preventDefault();
           const focusedId = selectActiveWorkspace(
             useWorkspaceStore.getState(),
-          ).focusedCardId;
+          )?.focusedCardId;
           if (focusedId) {
             const handle = panelRefs.get(focusedId);
             if (handle) {
@@ -63,7 +63,7 @@ export function useKeyboardShortcuts(): void {
         e.preventDefault();
         const state = useWorkspaceStore.getState();
         const ws = selectActiveWorkspace(state);
-        if (ws.rootId === null) {
+        if (!ws || ws.rootId === null) {
           state.addInitialCard();
           return;
         }
@@ -75,7 +75,7 @@ export function useKeyboardShortcuts(): void {
       } else if (e.key === "w" && !e.shiftKey) {
         e.preventDefault();
         const state = useWorkspaceStore.getState();
-        const { focusedCardId } = selectActiveWorkspace(state);
+        const focusedCardId = selectActiveWorkspace(state)?.focusedCardId;
         if (!focusedCardId) return;
         state.closeCard(focusedCardId);
       } else if (e.key === "t") {


### PR DESCRIPTION
## Summary

- Add private `getActiveWs()` helper in `workspaceStore.ts` that returns `Workspace | null`, replacing 8 repeated `draft.workspaces.find(...)!` non-null assertions inside store actions
- Change `selectActiveWorkspace` return type from `Workspace` to `Workspace | undefined` (remove `!`)
- Update all 5 callers (`Card.tsx`, `CardLayout.tsx`, `CardTree.tsx`, `useKeyboardShortcuts.ts`) to use optional chaining (`?.`) or explicit `!ws` guards so a corrupted/missing active workspace no longer throws a runtime error

## Test plan

- [ ] Open the app — normal workspace navigation still works
- [ ] Split cards, close cards, switch plugins — all actions behave correctly with a valid workspace
- [ ] No TypeScript errors (`tsc --noEmit`)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/100?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->