### PR TITLE
test(store): add workspace tab operation unit tests

### DIFF
--- a/src/store/workspaceStore.test.ts
+++ b/src/store/workspaceStore.test.ts
@@ -2,6 +2,8 @@
  * workspaceStore — Phase 1 (PoC) tests
  *
  * Tests the flat CardMap card operations: splitCard, closeCard, resizeSplit, setFocus.
+ * Also tests workspace tab operations: addWorkspace, closeWorkspace, setActiveWorkspace,
+ * switchToLastWorkspace, renameWorkspace, saveConfig, loadConfig, deleteConfig.
  * Store shape: { workspaces, activeWorkspaceId } — multi-workspace with persistence mock.
  */
 
@@ -520,5 +522,528 @@ describe("CardMap invariants", () => {
     const { nodes, rootId } = get();
     const reachable = reachableIds(nodes, rootId);
     expect(new Set(Object.keys(nodes))).toEqual(reachable);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addWorkspace
+// ---------------------------------------------------------------------------
+
+describe("addWorkspace", () => {
+  beforeEach(() => {
+    // Reset to a single clean workspace before each tab-level test
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: "default",
+          name: "Workspace 1",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+      ],
+      activeWorkspaceId: "default",
+      lastWorkspaceId: null,
+    });
+  });
+
+  it("appends a new workspace and makes it active", () => {
+    get().addWorkspace();
+
+    const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState();
+    expect(workspaces).toHaveLength(2);
+    expect(activeWorkspaceId).toBe(workspaces[1].id);
+  });
+
+  it("names the new workspace using the next sequential number", () => {
+    get().addWorkspace();
+
+    const { workspaces } = useWorkspaceStore.getState();
+    expect(workspaces[1].name).toBe("Workspace 2");
+  });
+
+  it("increments name based on current length, not a persistent counter", () => {
+    // Add two workspaces so length becomes 3
+    get().addWorkspace();
+    get().addWorkspace();
+
+    const { workspaces } = useWorkspaceStore.getState();
+    expect(workspaces[2].name).toBe("Workspace 3");
+  });
+
+  it("starts the new workspace with an empty card tree", () => {
+    get().addWorkspace();
+
+    const { workspaces } = useWorkspaceStore.getState();
+    const newWs = workspaces[1];
+    expect(newWs.rootId).toBeNull();
+    expect(newWs.nodes).toEqual({});
+    expect(newWs.focusedCardId).toBeNull();
+  });
+
+  it("assigns a unique id to each new workspace", () => {
+    get().addWorkspace();
+    get().addWorkspace();
+
+    const { workspaces } = useWorkspaceStore.getState();
+    const ids = workspaces.map((w) => w.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// closeWorkspace
+// ---------------------------------------------------------------------------
+
+describe("closeWorkspace", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: "default",
+          name: "Workspace 1",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+      ],
+      activeWorkspaceId: "default",
+      lastWorkspaceId: null,
+    });
+  });
+
+  it("edge case: closing the only workspace resets to one fresh empty workspace", () => {
+    get().closeWorkspace("default");
+
+    const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState();
+    expect(workspaces).toHaveLength(1);
+    expect(workspaces[0].name).toBe("Workspace 1");
+    expect(workspaces[0].rootId).toBeNull();
+    expect(workspaces[0].nodes).toEqual({});
+    // The new id must differ from the old one
+    expect(workspaces[0].id).not.toBe("default");
+    expect(activeWorkspaceId).toBe(workspaces[0].id);
+  });
+
+  it("edge case: closing the active tab activates the previous (left) tab", () => {
+    // Build: ws1 (default) | ws2 | ws3 — active is ws3 (idx 2)
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: "ws1",
+          name: "Workspace 1",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+        {
+          id: "ws2",
+          name: "Workspace 2",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+        {
+          id: "ws3",
+          name: "Workspace 3",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+      ],
+      activeWorkspaceId: "ws3",
+      lastWorkspaceId: null,
+    });
+
+    get().closeWorkspace("ws3");
+
+    const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState();
+    expect(workspaces).toHaveLength(2);
+    // Previous tab (idx 1 after removal, was idx 1 before) should be active
+    expect(activeWorkspaceId).toBe("ws2");
+  });
+
+  it("edge case: closing the first active tab falls back to the next tab (idx 0)", () => {
+    // Build: ws1 | ws2 — active is ws1 (idx 0)
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: "ws1",
+          name: "Workspace 1",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+        {
+          id: "ws2",
+          name: "Workspace 2",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+      ],
+      activeWorkspaceId: "ws1",
+      lastWorkspaceId: null,
+    });
+
+    get().closeWorkspace("ws1");
+
+    const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState();
+    expect(workspaces).toHaveLength(1);
+    expect(activeWorkspaceId).toBe("ws2");
+  });
+
+  it("closing a non-active workspace does not change activeWorkspaceId", () => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: "ws1",
+          name: "Workspace 1",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+        {
+          id: "ws2",
+          name: "Workspace 2",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+      ],
+      activeWorkspaceId: "ws1",
+      lastWorkspaceId: null,
+    });
+
+    get().closeWorkspace("ws2");
+
+    const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState();
+    expect(workspaces).toHaveLength(1);
+    expect(activeWorkspaceId).toBe("ws1");
+  });
+
+  it("does nothing when the id does not exist", () => {
+    get().closeWorkspace("nonexistent");
+
+    const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState();
+    expect(workspaces).toHaveLength(1);
+    expect(activeWorkspaceId).toBe("default");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setActiveWorkspace / switchToLastWorkspace
+// ---------------------------------------------------------------------------
+
+describe("setActiveWorkspace", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: "ws1",
+          name: "Workspace 1",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+        {
+          id: "ws2",
+          name: "Workspace 2",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+        {
+          id: "ws3",
+          name: "Workspace 3",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+      ],
+      activeWorkspaceId: "ws1",
+      lastWorkspaceId: null,
+    });
+  });
+
+  it("sets activeWorkspaceId to the given id", () => {
+    get().setActiveWorkspace("ws2");
+
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("ws2");
+  });
+
+  it("stores the previous activeWorkspaceId in lastWorkspaceId", () => {
+    get().setActiveWorkspace("ws2");
+
+    expect(useWorkspaceStore.getState().lastWorkspaceId).toBe("ws1");
+  });
+
+  it("updates lastWorkspaceId on successive switches", () => {
+    get().setActiveWorkspace("ws2");
+    get().setActiveWorkspace("ws3");
+
+    const state = useWorkspaceStore.getState();
+    expect(state.activeWorkspaceId).toBe("ws3");
+    expect(state.lastWorkspaceId).toBe("ws2");
+  });
+});
+
+describe("switchToLastWorkspace", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: "ws1",
+          name: "Workspace 1",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+        {
+          id: "ws2",
+          name: "Workspace 2",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+      ],
+      activeWorkspaceId: "ws2",
+      lastWorkspaceId: "ws1",
+    });
+  });
+
+  it("swaps activeWorkspaceId and lastWorkspaceId (toggle)", () => {
+    get().switchToLastWorkspace();
+
+    const state = useWorkspaceStore.getState();
+    expect(state.activeWorkspaceId).toBe("ws1");
+    expect(state.lastWorkspaceId).toBe("ws2");
+  });
+
+  it("calling it twice returns to the original state", () => {
+    get().switchToLastWorkspace();
+    get().switchToLastWorkspace();
+
+    const state = useWorkspaceStore.getState();
+    expect(state.activeWorkspaceId).toBe("ws2");
+    expect(state.lastWorkspaceId).toBe("ws1");
+  });
+
+  it("does nothing when lastWorkspaceId is null", () => {
+    useWorkspaceStore.setState({ lastWorkspaceId: null });
+
+    get().switchToLastWorkspace();
+
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("ws2");
+  });
+
+  it("does nothing when only one workspace exists", () => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: "ws1",
+          name: "Workspace 1",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+      ],
+      activeWorkspaceId: "ws1",
+      lastWorkspaceId: "ws1",
+    });
+
+    get().switchToLastWorkspace();
+
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("ws1");
+  });
+
+  it("does nothing when lastWorkspaceId points to a workspace that no longer exists", () => {
+    useWorkspaceStore.setState({ lastWorkspaceId: "ghost-id" });
+
+    get().switchToLastWorkspace();
+
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("ws2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renameWorkspace
+// ---------------------------------------------------------------------------
+
+describe("renameWorkspace", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: "ws1",
+          name: "Workspace 1",
+          rootId: null,
+          nodes: {},
+          focusedCardId: null,
+        },
+      ],
+      activeWorkspaceId: "ws1",
+      lastWorkspaceId: null,
+    });
+  });
+
+  it("updates the workspace name", () => {
+    get().renameWorkspace("ws1", "My Dashboard");
+
+    const ws = useWorkspaceStore
+      .getState()
+      .workspaces.find((w) => w.id === "ws1")!;
+    expect(ws.name).toBe("My Dashboard");
+  });
+
+  it("does nothing when the id does not exist", () => {
+    expect(() =>
+      get().renameWorkspace("nonexistent", "New Name"),
+    ).not.toThrow();
+
+    // The real workspace is unchanged
+    const ws = useWorkspaceStore
+      .getState()
+      .workspaces.find((w) => w.id === "ws1")!;
+    expect(ws.name).toBe("Workspace 1");
+  });
+
+  it("allows setting an empty string (no guard in current implementation)", () => {
+    // The store does not guard empty names — this test documents the actual behavior.
+    get().renameWorkspace("ws1", "");
+
+    const ws = useWorkspaceStore
+      .getState()
+      .workspaces.find((w) => w.id === "ws1")!;
+    expect(ws.name).toBe("");
+  });
+
+  it("allows whitespace-only names (no guard in current implementation)", () => {
+    get().renameWorkspace("ws1", "   ");
+
+    const ws = useWorkspaceStore
+      .getState()
+      .workspaces.find((w) => w.id === "ws1")!;
+    expect(ws.name).toBe("   ");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveConfig / loadConfig / deleteConfig
+// ---------------------------------------------------------------------------
+
+describe("saveConfig / loadConfig / deleteConfig", () => {
+  beforeEach(() => {
+    // Start with a workspace that has a simple two-leaf layout
+    const leafA = makeLeaf("leafA", "root-split");
+    const leafB = makeLeaf("leafB", "root-split");
+    const rootSplit = makeSplit("root-split", ["leafA", "leafB"]);
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: "ws1",
+          name: "Workspace 1",
+          rootId: "root-split",
+          nodes: { "root-split": rootSplit, leafA, leafB },
+          focusedCardId: "leafA",
+        },
+      ],
+      activeWorkspaceId: "ws1",
+      lastWorkspaceId: null,
+      savedConfigs: [],
+    });
+  });
+
+  it("saveConfig appends a new entry to savedConfigs", () => {
+    get().saveConfig("My Layout");
+
+    const { savedConfigs } = useWorkspaceStore.getState();
+    expect(savedConfigs).toHaveLength(1);
+    expect(savedConfigs[0].name).toBe("My Layout");
+  });
+
+  it("saveConfig snapshot captures rootId and nodes of the active workspace", () => {
+    get().saveConfig("Snapshot Test");
+
+    const { savedConfigs, workspaces, activeWorkspaceId } =
+      useWorkspaceStore.getState();
+    const ws = workspaces.find((w) => w.id === activeWorkspaceId)!;
+    const snap = savedConfigs[0].snapshot!;
+    expect(snap.rootId).toBe(ws.rootId);
+    expect(snap.nodes).toEqual(ws.nodes);
+  });
+
+  it("saveConfig records a non-empty id and ISO savedAt timestamp", () => {
+    get().saveConfig("Timestamped");
+
+    const config = useWorkspaceStore.getState().savedConfigs[0];
+    expect(config.id).toBeTruthy();
+    // Must be a valid ISO-8601 date string
+    expect(() => new Date(config.savedAt).toISOString()).not.toThrow();
+  });
+
+  it("saveConfig snapshot is a copy — mutating the workspace does not retroactively change the snapshot", () => {
+    get().saveConfig("Before Mutation");
+    const snapBefore = {
+      ...useWorkspaceStore.getState().savedConfigs[0].snapshot!,
+    };
+
+    // Remove all cards from the workspace
+    setWorkspace({ rootId: null, nodes: {}, focusedCardId: null });
+
+    const snap = useWorkspaceStore.getState().savedConfigs[0].snapshot!;
+    expect(snap.rootId).toBe(snapBefore.rootId);
+    expect(snap.nodes).toEqual(snapBefore.nodes);
+  });
+
+  it("loadConfig creates a new workspace from the saved snapshot and makes it active", () => {
+    get().saveConfig("Reload Me");
+    const configId = useWorkspaceStore.getState().savedConfigs[0].id;
+
+    get().loadConfig(configId);
+
+    const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState();
+    expect(workspaces).toHaveLength(2);
+    const loaded = workspaces.find((w) => w.id === activeWorkspaceId)!;
+    expect(loaded.name).toBe("Reload Me");
+    expect(loaded.rootId).toBe("root-split");
+    expect(loaded.nodes).toEqual(
+      expect.objectContaining({ "root-split": expect.any(Object) }),
+    );
+  });
+
+  it("loadConfig does nothing when configId does not exist", () => {
+    const before = useWorkspaceStore.getState().workspaces.length;
+    get().loadConfig("nonexistent");
+
+    expect(useWorkspaceStore.getState().workspaces).toHaveLength(before);
+  });
+
+  it("deleteConfig removes the entry from savedConfigs", () => {
+    get().saveConfig("To Delete");
+    const configId = useWorkspaceStore.getState().savedConfigs[0].id;
+
+    get().deleteConfig(configId);
+
+    expect(useWorkspaceStore.getState().savedConfigs).toHaveLength(0);
+  });
+
+  it("deleteConfig only removes the targeted entry, leaving others intact", () => {
+    get().saveConfig("Keep Me");
+    get().saveConfig("Delete Me");
+    const ids = useWorkspaceStore.getState().savedConfigs.map((c) => c.id);
+
+    get().deleteConfig(ids[1]);
+
+    const { savedConfigs } = useWorkspaceStore.getState();
+    expect(savedConfigs).toHaveLength(1);
+    expect(savedConfigs[0].id).toBe(ids[0]);
+  });
+
+  it("deleteConfig does nothing when configId does not exist", () => {
+    get().saveConfig("Existing");
+    get().deleteConfig("nonexistent");
+
+    expect(useWorkspaceStore.getState().savedConfigs).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- Adds 31 new unit tests across 6 describe blocks covering all previously untested workspace tab actions
- Groups: `addWorkspace`, `closeWorkspace`, `setActiveWorkspace`, `switchToLastWorkspace`, `renameWorkspace`, `saveConfig / loadConfig / deleteConfig`
- Each describe block has its own `beforeEach` that fully resets the workspaces array to avoid cross-test leakage

## Test coverage added

**addWorkspace** — name incrementing, uniqueness, empty card tree on creation

**closeWorkspace** — edge case: closing the last workspace resets to a fresh workspace with a new id; edge case: closing the active tab activates the previous tab; edge case: closing the first active tab falls back to the next; closing a non-active tab leaves active unchanged; no-op on unknown id

**setActiveWorkspace** — sets active id, stores previous id in `lastWorkspaceId`, tracks correctly on successive switches

**switchToLastWorkspace** — swaps active and last ids (toggle), calling twice returns to original state, no-op when `lastWorkspaceId` is null, no-op when only one workspace exists, no-op when `lastWorkspaceId` points to a removed workspace

**renameWorkspace** — updates name, no-op on unknown id, documents that empty/whitespace names are not guarded (actual behavior)

**saveConfig / loadConfig / deleteConfig** — snapshot captures rootId and nodes, id and ISO timestamp are set, snapshot is a shallow copy (mutations don't retroactively change it), loadConfig creates a new workspace from snapshot, deleteConfig removes only the targeted entry

## Test plan
- [x] All 53 tests pass (`npx vitest run src/store/workspaceStore.test.ts`)
- [x] No changes to production code

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/101?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->