### PR TITLE
feat(layout): add equal-split and main-sidebar layout presets

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -55,6 +55,14 @@ export function useKeyboardShortcuts(): void {
               handle.resize(String(Math.max(pct - 5, 5)));
             }
           }
+        } else if (e.code === "Digit0") {
+          // CMD+Opt+0 : equalize all panels
+          e.preventDefault();
+          useWorkspaceStore.getState().applyLayoutPreset("equal");
+        } else if (e.code === "KeyM") {
+          // CMD+Opt+M : main + sidebar (focused 60%, sibling 40%)
+          e.preventDefault();
+          useWorkspaceStore.getState().applyLayoutPreset("main-sidebar");
         }
         return;
       }


### PR DESCRIPTION
## Summary

- Adds `applyLayoutPreset(preset: 'equal' | 'main-sidebar')` action to `workspaceStore`
- **Equal split (CMD+Opt+0)**: iterates all split nodes in the active workspace and resizes each pair of children to 50/50 via their `PanelImperativeHandle` refs
- **Main + sidebar (CMD+Opt+M)**: resizes the immediate parent PanelGroup of the focused panel — focused gets 60%, its sibling gets 40%
- Both shortcuts wired into `useKeyboardShortcuts` inside the existing `CMD+Opt+…` block with `preventDefault()`
- Pure resize operations — no `NodeMap` mutations; uses the existing `panelRefs` module

## Implementation details

- `applyLayoutPreset` reads state via `useWorkspaceStore.getState()` (same pattern as keyboard shortcut handlers) and calls `.resize()` on handles from `panelRefs`
- `panelRefs` keys are `childIds` of split nodes (as registered in `CardTree.tsx`), which correctly handles both leaf and nested-split children
- `applyLayoutPreset` is omitted from `filterKeys` in the Tauri store config so it is not persisted (actions are already omitted via the `omit` strategy)

## Test plan

- [ ] Open app with a single panel — CMD+Opt+0 and CMD+Opt+M are no-ops (no split to resize)
- [ ] Split into two panels horizontally — CMD+Opt+0 equalizes to 50/50
- [ ] Drag one panel to an unequal size — CMD+Opt+0 restores 50/50
- [ ] Focus the wider panel — CMD+Opt+M sets it to 60%, sibling to 40%
- [ ] Create a 3-panel layout (A | B horizontal, then B split vertically into B1/B2) — CMD+Opt+0 equalizes all groups; focus B1 then CMD+Opt+M sets B1=60%, B2=40% within their group
- [ ] Verify CMD+Opt+= and CMD+Opt+- (existing shortcuts) still work correctly

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/102?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->