### PR TITLE
feat(ui): add CMD+Opt+G workspace overview HUD

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,21 @@
-import { useEffect } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { appDataDir } from "@tauri-apps/api/path";
-import { useWorkspaceStore } from "@/store/workspaceStore";
+import {
+  useWorkspaceStore,
+  selectActiveWorkspace,
+} from "@/store/workspaceStore";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import CardLayout from "@/components/CardLayout";
 import TabBar from "@/components/TabBar";
+import WorkspaceOverlay from "@/components/WorkspaceOverlay";
 
 function App() {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const setAppDataDir = useWorkspaceStore((s) => s.setAppDataDir);
+  const workspace = useWorkspaceStore(selectActiveWorkspace);
+  const setFocus = useWorkspaceStore((s) => s.setFocus);
+
+  const [showOverlay, setShowOverlay] = useState(false);
 
   useKeyboardShortcuts();
 
@@ -15,12 +23,52 @@ function App() {
     appDataDir().then(setAppDataDir);
   }, [setAppDataDir]);
 
+  // CMD+Opt+G — toggle workspace overview HUD
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent): void {
+      if (e.metaKey && e.altKey && e.code === "KeyG") {
+        e.preventDefault();
+        setShowOverlay((prev) => !prev);
+        return;
+      }
+      // Any keypress while overlay is open dismisses it (except modifier-only keys)
+      if (showOverlay && !e.metaKey && !e.altKey && !e.ctrlKey) {
+        if (
+          e.key === "Escape" ||
+          (!e.key.startsWith("F") && e.key !== "Tab")
+        ) {
+          setShowOverlay(false);
+        }
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [showOverlay]);
+
+  const handleSelectCard = useCallback(
+    (cardId: string) => {
+      setFocus(cardId);
+      setShowOverlay(false);
+    },
+    [setFocus],
+  );
+
   return (
     <div className="flex h-screen flex-col">
       <TabBar />
       <div className="flex-1 overflow-hidden">
         <CardLayout key={activeWorkspaceId} />
       </div>
+
+      {showOverlay && (
+        <WorkspaceOverlay
+          nodes={workspace.nodes}
+          rootId={workspace.rootId}
+          focusedCardId={workspace.focusedCardId}
+          onSelectCard={handleSelectCard}
+          onClose={() => setShowOverlay(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/WorkspaceOverlay.tsx
+++ b/src/components/WorkspaceOverlay.tsx
@@ -1,0 +1,166 @@
+import type { CardId, CardMap, CardNode } from "@/types/card";
+import { getPlugin } from "@/plugins/registry";
+import { cn } from "@/lib/utils";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  /** Flat node map for the active workspace */
+  nodes: CardMap;
+  /** Root node id (null = empty workspace) */
+  rootId: CardId | null;
+  /** Currently focused card id */
+  focusedCardId: CardId | null;
+  /** Called when the user clicks a leaf panel in the overview */
+  onSelectCard: (cardId: CardId) => void;
+  /** Called when the overlay should close (backdrop click, keyboard) */
+  onClose: () => void;
+}
+
+// ─── Mini panel tree ─────────────────────────────────────────────────────────
+
+interface NodeProps {
+  nodeId: CardId;
+  nodes: CardMap;
+  focusedCardId: CardId | null;
+  onSelectCard: (cardId: CardId) => void;
+}
+
+function MiniNode({ nodeId, nodes, focusedCardId, onSelectCard }: NodeProps) {
+  const node: CardNode | undefined = nodes[nodeId];
+  if (!node) return null;
+
+  if (node.type === "split") {
+    const [firstId, secondId] = node.childIds;
+    const [firstSize, secondSize] = node.sizes;
+
+    return (
+      <div
+        className={cn(
+          "flex h-full w-full gap-[2px]",
+          node.direction === "horizontal" ? "flex-row" : "flex-col",
+        )}
+      >
+        <div
+          style={{ flex: firstSize }}
+          className="min-h-0 min-w-0 overflow-hidden"
+        >
+          <MiniNode
+            nodeId={firstId}
+            nodes={nodes}
+            focusedCardId={focusedCardId}
+            onSelectCard={onSelectCard}
+          />
+        </div>
+        <div
+          style={{ flex: secondSize }}
+          className="min-h-0 min-w-0 overflow-hidden"
+        >
+          <MiniNode
+            nodeId={secondId}
+            nodes={nodes}
+            focusedCardId={focusedCardId}
+            onSelectCard={onSelectCard}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // Leaf node
+  const isFocused = node.id === focusedCardId;
+  const pluginEntry = node.pluginId ? getPlugin(node.pluginId) : undefined;
+  const label = pluginEntry?.name ?? (node.pluginId ? node.pluginId : "Empty");
+
+  return (
+    <button
+      className={cn(
+        "pointer-events-auto flex h-full w-full cursor-pointer items-center justify-center overflow-hidden rounded-[3px] border transition-colors",
+        isFocused
+          ? "border-foreground/60 bg-foreground/10 ring-1 ring-inset ring-foreground/40"
+          : "border-border/60 bg-muted/40 hover:bg-muted/70 hover:border-foreground/30",
+      )}
+      onClick={(e) => {
+        e.stopPropagation();
+        onSelectCard(node.id);
+      }}
+      title={label}
+    >
+      <span className="truncate px-1 text-[9px] font-medium leading-none text-muted-foreground">
+        {label}
+      </span>
+    </button>
+  );
+}
+
+// ─── WorkspaceOverlay ─────────────────────────────────────────────────────────
+
+export default function WorkspaceOverlay({
+  nodes,
+  rootId,
+  focusedCardId,
+  onSelectCard,
+  onClose,
+}: Props) {
+  const isEmpty = rootId === null;
+
+  return (
+    // Full-screen backdrop — pointer events on the backdrop element dismiss the overlay
+    <div
+      className="pointer-events-auto fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm animate-in fade-in duration-150"
+      onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onClose();
+      }}
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+      role="dialog"
+      aria-modal="true"
+      aria-label="Workspace overview"
+    >
+      {/* Card — stop click propagation so only backdrop click dismisses */}
+      <div
+        className="pointer-events-auto flex flex-col gap-3 rounded-xl border border-border/80 bg-background/95 p-4 shadow-2xl animate-in zoom-in-95 fade-in duration-150"
+        style={{ width: 440, maxWidth: "calc(100vw - 48px)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+            Workspace overview
+          </span>
+          <kbd className="rounded border border-border px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground">
+            esc
+          </kbd>
+        </div>
+
+        {/* Panel map */}
+        <div
+          className="overflow-hidden rounded-md border border-border/60 bg-muted/20"
+          style={{ height: 280 }}
+        >
+          {isEmpty ? (
+            <div className="flex h-full items-center justify-center">
+              <span className="text-xs text-muted-foreground">
+                No panels open
+              </span>
+            </div>
+          ) : (
+            <div className="h-full p-2">
+              <MiniNode
+                nodeId={rootId}
+                nodes={nodes}
+                focusedCardId={focusedCardId}
+                onSelectCard={onSelectCard}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Footer hint */}
+        <p className="text-[10px] text-muted-foreground/70">
+          Click a panel to focus it — or press any key to dismiss
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a lightweight panel map HUD triggered by `CMD+Opt+G`
- `WorkspaceOverlay` component recursively walks the flat `CardMap` from root, rendering split nodes as proportional flex containers (honouring `sizes`) and leaf nodes as labelled miniature panels
- Focused panel is highlighted with a ring; clicking any mini-panel sets it as `focusedCardId` and closes the HUD
- Dismisses on: backdrop click, `Escape`, or any non-modifier keypress
- Animates in via Tailwind `animate-in fade-in zoom-in-95`
- No store changes — purely stateless, reads from existing workspace store

## Test plan

- [ ] `CMD+Opt+G` opens the overlay
- [ ] `CMD+Opt+G` again closes it (toggle)
- [ ] `Escape` closes it
- [ ] Clicking the backdrop closes it
- [ ] Any letter/number key press closes it
- [ ] Overlay shows "No panels open" for an empty workspace
- [ ] Split layout mirrors actual workspace proportions (horizontal vs vertical, correct sizes)
- [ ] Focused panel has a visible ring highlight
- [ ] Clicking a mini-panel focuses that card and closes the HUD
- [ ] Plugin name is displayed in each leaf panel ("Notepad", "Terminal", etc.)
- [ ] Empty leaf panels show "Empty"
- [ ] Works correctly after switching workspaces

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/103?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->