### PR TITLE
feat(plugin-host): add panel lifecycle event bus to PluginContext

### DIFF
--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -2,6 +2,7 @@ export type {
   PluginBus,
   PluginManifest,
   PluginContext,
+  PluginLifecycleEvent,
   PluginComponent,
   PluginModule,
 } from "./plugin";

--- a/plugins/api/src/plugin.ts
+++ b/plugins/api/src/plugin.ts
@@ -22,6 +22,14 @@ export interface PluginManifest {
   icon?: string;
 }
 
+/** Panel lifecycle event names emitted by PluginHost. */
+export type PluginLifecycleEvent =
+  | "focus"
+  | "blur"
+  | "resize"
+  | "zoom"
+  | "zoom-exit";
+
 /** Runtime context injected by PluginHost into every plugin component */
 export interface PluginContext {
   /** Unique ID of the card this instance is mounted in */
@@ -32,6 +40,14 @@ export interface PluginContext {
   theme: "light" | "dark";
   /** Inter-plugin communication bus */
   bus: PluginBus;
+  /**
+   * Subscribe to a panel lifecycle event.
+   * Returns an unsubscribe function — call it in your plugin's cleanup.
+   *
+   * @example
+   * useEffect(() => context.on('focus', () => console.log('focused')), []);
+   */
+  on(event: PluginLifecycleEvent, handler: () => void): () => void;
 }
 
 export type PluginComponent = React.ComponentType<{ context: PluginContext }>;

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -5,10 +5,10 @@ import {
 } from "@/store/workspaceStore";
 import EmptyState from "@/components/EmptyState";
 import PluginHost from "@/components/PluginHost";
-import type { PluginContext } from "@/types/plugin";
 import { pluginBus } from "@/lib/pluginBus";
 import { cn } from "@/lib/utils";
 import { useSystemTheme } from "@/hooks/useSystemTheme";
+import type { PluginContext } from "@/types/plugin";
 
 interface Props {
   nodeId: string;
@@ -26,7 +26,7 @@ function Card({ nodeId }: Props) {
   const pluginId = node?.type === "leaf" ? node.pluginId : null;
   const theme = useSystemTheme();
 
-  const pluginContext = useMemo<PluginContext>(
+  const pluginContext = useMemo<Omit<PluginContext, "on">>(
     () => ({
       cardId: nodeId,
       workspacePath: appDataDir,
@@ -54,7 +54,7 @@ function Card({ nodeId }: Props) {
       {pluginId === null ? (
         <EmptyState cardId={nodeId} />
       ) : (
-        <PluginHost pluginId={pluginId} context={pluginContext} />
+        <PluginHost pluginId={pluginId} nodeId={nodeId} context={pluginContext} />
       )}
 
       <button

--- a/src/components/PluginHost.tsx
+++ b/src/components/PluginHost.tsx
@@ -1,21 +1,115 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { loadPlugin, getCachedPlugin } from "@/plugins/loader";
-import type { PluginComponent, PluginContext } from "@/types/plugin";
+import {
+  useWorkspaceStore,
+  selectActiveWorkspace,
+} from "@/store/workspaceStore";
+import type {
+  PluginComponent,
+  PluginContext,
+  PluginLifecycleEvent,
+} from "@/types/plugin";
+
+// ─── Lightweight per-panel event emitter ────────────────────────────────────
+
+type HandlerSet = Set<() => void>;
+
+function createEmitter() {
+  const listeners = new Map<string, HandlerSet>();
+
+  function on(event: string, handler: () => void): () => void {
+    if (!listeners.has(event)) listeners.set(event, new Set());
+    listeners.get(event)!.add(handler);
+    return () => listeners.get(event)?.delete(handler);
+  }
+
+  function emit(event: string): void {
+    listeners.get(event)?.forEach((h) => h());
+  }
+
+  return { on, emit };
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
 
 interface Props {
   pluginId: string;
-  context: PluginContext;
+  /** The card ID for this panel — used to derive focus/zoom state. */
+  nodeId: string;
+  context: Omit<PluginContext, "on">;
 }
 
-function PluginHostInner({ pluginId, context }: Props) {
+function PluginHostInner({ pluginId, nodeId, context }: Props) {
   const [Component, setComponent] = useState<PluginComponent | null>(
     () => getCachedPlugin(pluginId)?.default ?? null,
   );
   const [error, setError] = useState<string | null>(null);
 
+  // ── Emitter (stable across renders) ───────────────────────────────────────
+  const emitterRef = useRef(createEmitter());
+  const emit = emitterRef.current.emit;
+
+  // ── Store subscriptions ───────────────────────────────────────────────────
+  const focusedCardId = useWorkspaceStore(
+    (s) => selectActiveWorkspace(s).focusedCardId,
+  );
+  const zoomedCardId = useWorkspaceStore(
+    (s) => selectActiveWorkspace(s).zoomedCardId,
+  );
+
+  // ── focus / blur ──────────────────────────────────────────────────────────
   useEffect(() => {
-    // If already cached, component is already set — skip the flash
+    if (focusedCardId === nodeId) {
+      emit("focus");
+    } else {
+      emit("blur");
+    }
+  }, [focusedCardId, nodeId, emit]);
+
+  // ── zoom / zoom-exit ──────────────────────────────────────────────────────
+  const prevZoomedRef = useRef<string | null>(null);
+  useEffect(() => {
+    const prev = prevZoomedRef.current;
+    prevZoomedRef.current = zoomedCardId;
+
+    if (zoomedCardId === nodeId && prev !== nodeId) {
+      emit("zoom");
+    } else if (prev === nodeId && zoomedCardId !== nodeId) {
+      emit("zoom-exit");
+    }
+  }, [zoomedCardId, nodeId, emit]);
+
+  // ── resize (ResizeObserver on the container element) ──────────────────────
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const observer = new ResizeObserver(() => {
+      if (debounceTimer !== null) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => emit("resize"), 100);
+    });
+
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      if (debounceTimer !== null) clearTimeout(debounceTimer);
+    };
+  }, [emit]);
+
+  // ── Stable `on` bound to this panel's emitter ────────────────────────────
+  const on = useCallback(
+    (event: PluginLifecycleEvent, handler: () => void): (() => void) =>
+      emitterRef.current.on(event, handler),
+    [],
+  );
+
+  // ── Plugin loading ────────────────────────────────────────────────────────
+  useEffect(() => {
     if (!getCachedPlugin(pluginId)) {
       setComponent(null);
       setError(null);
@@ -27,6 +121,8 @@ function PluginHostInner({ pluginId, context }: Props) {
       })
       .catch((err) => setError(String(err?.message ?? err)));
   }, [pluginId]);
+
+  const fullContext: PluginContext = { ...context, on };
 
   if (error) {
     return (
@@ -42,10 +138,14 @@ function PluginHostInner({ pluginId, context }: Props) {
       </div>
     );
   }
-  return <Component context={context} />;
+  return (
+    <div ref={containerRef} className="h-full w-full">
+      <Component context={fullContext} />
+    </div>
+  );
 }
 
-export default function PluginHost({ pluginId, context }: Props) {
+export default function PluginHost({ pluginId, nodeId, context }: Props) {
   return (
     <ErrorBoundary
       resetKeys={[pluginId]}
@@ -55,7 +155,7 @@ export default function PluginHost({ pluginId, context }: Props) {
         </div>
       )}
     >
-      <PluginHostInner pluginId={pluginId} context={context} />
+      <PluginHostInner pluginId={pluginId} nodeId={nodeId} context={context} />
     </ErrorBoundary>
   );
 }

--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -35,6 +35,7 @@ type WorkspaceActions = {
   saveConfig: (name: string) => void;
   loadConfig: (configId: string) => void;
   deleteConfig: (configId: string) => void;
+  setZoom: (cardId: CardId | null) => void;
   setPendingSaveName: (v: boolean) => void;
   setAppDataDir: (path: string) => void;
   applyLayoutPreset: (preset: "equal" | "main-sidebar") => void;
@@ -45,7 +46,14 @@ export type WorkspaceStore = WorkspaceState & WorkspaceActions;
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function emptyWorkspace(id: WorkspaceId, name: string): Workspace {
-  return { id, name, rootId: null, nodes: {}, focusedCardId: null };
+  return {
+    id,
+    name,
+    rootId: null,
+    nodes: {},
+    focusedCardId: null,
+    zoomedCardId: null,
+  };
 }
 
 function getActiveWs(
@@ -241,6 +249,14 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
           ws.focusedCardId = cardId;
         }),
 
+      setZoom: (cardId) =>
+        set((draft) => {
+          const ws = draft.workspaces.find(
+            (w) => w.id === draft.activeWorkspaceId,
+          )!;
+          ws.zoomedCardId = cardId;
+        }),
+
       moveFocus: (direction) =>
         set((draft) => {
           const ws = getActiveWs(draft);
@@ -329,6 +345,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
             rootId: config.snapshot.rootId,
             nodes: { ...config.snapshot.nodes },
             focusedCardId: null,
+            zoomedCardId: null,
           });
           draft.activeWorkspaceId = newId;
         }),

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,6 +1,7 @@
 export type {
   PluginManifest,
   PluginContext,
+  PluginLifecycleEvent,
   PluginComponent,
   PluginModule,
 } from "@origin/api";

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -8,6 +8,8 @@ export interface Workspace {
   rootId: CardId | null;
   nodes: CardMap;
   focusedCardId: CardId | null;
+  /** Card currently expanded to fill the workspace; null when no card is zoomed. */
+  zoomedCardId: CardId | null;
 }
 
 export interface SavedConfig {


### PR DESCRIPTION
## Summary

- Adds `PluginLifecycleEvent` union type (`focus | blur | resize | zoom | zoom-exit`) to `@origin/api`
- Extends `PluginContext` with `on(event, handler): () => void` — subscribe to panel lifecycle events; return value is the unsubscribe function
- Implements a lightweight per-panel `EventEmitter` (Map of event → Set of handlers) inside `PluginHost` using `useRef` — no external dependency
- Wires `focus`/`blur` via a `useEffect` on `focusedCardId` from the Zustand store
- Wires `resize` via a `ResizeObserver` on the panel container div (100 ms debounce)
- Wires `zoom`/`zoom-exit` via a `useEffect` + `prevZoomedRef` tracking `zoomedCardId` transitions
- Adds `zoomedCardId: CardId | null` to the `Workspace` type and `setZoom` action to the workspace store
- `PluginHost` now receives `nodeId` (in addition to the existing `context`) so it can self-subscribe to store slices
- Existing plugins that do not call `context.on` are entirely unaffected

## Test plan

- [ ] Open two panels side by side; click panel A → `focus` fires on A, `blur` fires on B
- [ ] Drag the panel divider → `resize` fires on both panels after ~100 ms
- [ ] Call `store.setZoom(nodeId)` → `zoom` fires on that panel; `setZoom(null)` → `zoom-exit` fires
- [ ] Verify a plugin that never calls `context.on` still renders without errors
- [ ] `npx tsc --noEmit` passes

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/104?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->