### PR TITLE
feat(store): add swapPanel action for keyboard panel rearrangement

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,10 +33,7 @@ function App() {
       }
       // Any keypress while overlay is open dismisses it (except modifier-only keys)
       if (showOverlay && !e.metaKey && !e.altKey && !e.ctrlKey) {
-        if (
-          e.key === "Escape" ||
-          (!e.key.startsWith("F") && e.key !== "Tab")
-        ) {
+        if (e.key === "Escape" || (!e.key.startsWith("F") && e.key !== "Tab")) {
           setShowOverlay(false);
         }
       }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -18,7 +18,9 @@ function Card({ nodeId }: Props) {
   const isFocused = useWorkspaceStore(
     (s) => selectActiveWorkspace(s)?.focusedCardId === nodeId,
   );
-  const node = useWorkspaceStore((s) => selectActiveWorkspace(s)?.nodes[nodeId]);
+  const node = useWorkspaceStore(
+    (s) => selectActiveWorkspace(s)?.nodes[nodeId],
+  );
   const setFocus = useWorkspaceStore((s) => s.setFocus);
   const closeCard = useWorkspaceStore((s) => s.closeCard);
   const appDataDir = useWorkspaceStore((s) => s.appDataDir);
@@ -54,7 +56,11 @@ function Card({ nodeId }: Props) {
       {pluginId === null ? (
         <EmptyState cardId={nodeId} />
       ) : (
-        <PluginHost pluginId={pluginId} nodeId={nodeId} context={pluginContext} />
+        <PluginHost
+          pluginId={pluginId}
+          nodeId={nodeId}
+          context={pluginContext}
+        />
       )}
 
       <button

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -13,6 +13,24 @@ export function useKeyboardShortcuts(): void {
 
       // ── CMD+Opt+… shortcuts ──────────────────────────────────────────────
       if (e.altKey) {
+        // ── CMD+Shift+Opt+… : swap focused panel in a direction ────────────
+        if (e.shiftKey) {
+          if (e.code === "KeyH" || e.code === "ArrowLeft") {
+            e.preventDefault();
+            useWorkspaceStore.getState().swapPanel("left");
+          } else if (e.code === "KeyL" || e.code === "ArrowRight") {
+            e.preventDefault();
+            useWorkspaceStore.getState().swapPanel("right");
+          } else if (e.code === "KeyK" || e.code === "ArrowUp") {
+            e.preventDefault();
+            useWorkspaceStore.getState().swapPanel("up");
+          } else if (e.code === "KeyJ" || e.code === "ArrowDown") {
+            e.preventDefault();
+            useWorkspaceStore.getState().swapPanel("down");
+          }
+          return;
+        }
+
         if (e.code === "Tab") {
           // CMD+Opt+Tab: toggle last workspace
           e.preventDefault();

--- a/src/hooks/useSystemTheme.ts
+++ b/src/hooks/useSystemTheme.ts
@@ -7,7 +7,9 @@ import { useState, useEffect } from "react";
  */
 export function useSystemTheme(): "light" | "dark" {
   const [theme, setTheme] = useState<"light" | "dark">(
-    window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light",
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light",
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Adds `swapPanel(direction)` action to the workspace store — reuses the same directional tree traversal as `moveFocus` to locate the pivot ancestor split, then reverses its `childIds` to swap both subtrees in O(1)
- Wires `CMD+Shift+Opt+H/J/K/L` (and Arrow key equivalents) in `useKeyboardShortcuts` to call `swapPanel`; focus stays on the same panel ID after the swap
- Adds `swapPanel` to the Tauri persistence `filterKeys` omit list (action, not state)

## Test plan

- [ ] Two-leaf horizontal split: focus right leaf, `CMD+Shift+Opt+H` → panels swap, focus stays on same panel
- [ ] Two-leaf horizontal split: focus left leaf, `CMD+Shift+Opt+L` → panels swap
- [ ] Two-leaf vertical split: focus bottom leaf, `CMD+Shift+Opt+K` → panels swap
- [ ] Cross-parent swap: `[leafA, [leafB, leafC]]`, focus `leafB`, swap left → `[[leafB, leafC], leafA]`
- [ ] No-op: focus leftmost panel, `CMD+Shift+Opt+H` → nothing changes
- [ ] Arrow key aliases: same results with `CMD+Shift+Opt+ArrowLeft` etc.
- [ ] `CMD+Opt+H/J/K/L` (no Shift) still moves focus as before — not broken
- [ ] All 9 new `swapPanel` unit tests pass: `npm test -- --run`

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/105?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->