### PR TITLE
feat(layout): add CMD+Opt+F panel zoom mode

### DIFF
--- a/src/components/CardLayout.tsx
+++ b/src/components/CardLayout.tsx
@@ -4,17 +4,24 @@ import {
 } from "@/store/workspaceStore";
 import EmptyState from "./EmptyState";
 import CardTree from "./CardTree";
+import Card from "./Card";
 
 function CardLayout() {
   const rootId = useWorkspaceStore((s) => selectActiveWorkspace(s)?.rootId);
+  const zoomedNodeId = useWorkspaceStore((s) => s.zoomedNodeId);
 
   if (!rootId) {
     return <EmptyState />;
   }
 
   return (
-    <div className="h-full w-full">
+    <div className="relative h-full w-full">
       <CardTree nodeId={rootId} />
+      {zoomedNodeId !== null && (
+        <div className="absolute inset-0 z-50">
+          <Card nodeId={zoomedNodeId} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -81,6 +81,14 @@ export function useKeyboardShortcuts(): void {
           // CMD+Opt+M : main + sidebar (focused 60%, sibling 40%)
           e.preventDefault();
           useWorkspaceStore.getState().applyLayoutPreset("main-sidebar");
+        } else if (e.code === "KeyF") {
+          // CMD+Opt+F : toggle zoom on focused panel
+          e.preventDefault();
+          const state = useWorkspaceStore.getState();
+          const focusedCardId = selectActiveWorkspace(state)?.focusedCardId;
+          if (!focusedCardId) return;
+          const current = state.zoomedNodeId;
+          state.setZoomedNodeId(current === focusedCardId ? null : focusedCardId);
         }
         return;
       }
@@ -101,6 +109,11 @@ export function useKeyboardShortcuts(): void {
       } else if (e.key === "w" && !e.shiftKey) {
         e.preventDefault();
         const state = useWorkspaceStore.getState();
+        // If a zoom overlay is active, dismiss it first instead of closing the panel
+        if (state.zoomedNodeId !== null) {
+          state.setZoomedNodeId(null);
+          return;
+        }
         const focusedCardId = selectActiveWorkspace(state)?.focusedCardId;
         if (!focusedCardId) return;
         state.closeCard(focusedCardId);


### PR DESCRIPTION
## Summary

- Adds `zoomedNodeId: string | null` to `WorkspaceStore` (ephemeral, excluded from Tauri persistence)
- `CardLayout` renders an `absolute inset-0 z-50` overlay `<Card>` when `zoomedNodeId` is set — the underlying `PanelGroup` tree stays mounted so plugins keep their state
- `CMD+Opt+F` toggles zoom on the focused panel; pressing again on the same panel dismisses it
- `CMD+W` while zoom is active dismisses the overlay instead of closing the panel
- Tab/workspace switches (`setActiveWorkspace`, `switchToLastWorkspace`) automatically clear `zoomedNodeId`

## Test plan

- [ ] Open a workspace with 2+ panels, focus one, press `CMD+Opt+F` — it fills the full workspace area
- [ ] Press `CMD+Opt+F` again — returns to normal tiled view
- [ ] While zoomed, press `CMD+W` — zoom dismisses; panel is NOT closed
- [ ] While zoomed, switch to another workspace tab — zoom is cleared on return
- [ ] Verify plugins in non-zoomed panels retain their state while zoom is active (e.g. text in Notepad)
- [ ] Verify `zoomedNodeId` is not restored after app restart

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/106?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->