### PR TITLE
feat(shortcuts): auto-open launcher in new panel after split

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -24,6 +24,9 @@ function Card({ nodeId }: Props) {
   const setFocus = useWorkspaceStore((s) => s.setFocus);
   const closeCard = useWorkspaceStore((s) => s.closeCard);
   const appDataDir = useWorkspaceStore((s) => s.appDataDir);
+  const launcherOpenForNodeId = useWorkspaceStore(
+    (s) => s.launcherOpenForNodeId,
+  );
 
   const pluginId = node?.type === "leaf" ? node.pluginId : null;
   const theme = useSystemTheme();
@@ -54,7 +57,10 @@ function Card({ nodeId }: Props) {
       onClick={() => setFocus(nodeId)}
     >
       {pluginId === null ? (
-        <EmptyState cardId={nodeId} />
+        <EmptyState
+          cardId={nodeId}
+          autoOpen={launcherOpenForNodeId === nodeId}
+        />
       ) : (
         <PluginHost
           pluginId={pluginId}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -88,7 +88,9 @@ export function useKeyboardShortcuts(): void {
           const focusedCardId = selectActiveWorkspace(state)?.focusedCardId;
           if (!focusedCardId) return;
           const current = state.zoomedNodeId;
-          state.setZoomedNodeId(current === focusedCardId ? null : focusedCardId);
+          state.setZoomedNodeId(
+            current === focusedCardId ? null : focusedCardId,
+          );
         }
         return;
       }


### PR DESCRIPTION
## Summary

- Adds `launcherOpenForNodeId: string | null` and `splitAutoLaunch: boolean` (default `true`) to `WorkspaceStore`
- `splitCard` sets `launcherOpenForNodeId = newLeafId` whenever `splitAutoLaunch` is true — no keyboard shortcut changes required
- `Card` passes `autoOpen={launcherOpenForNodeId === nodeId}` to `EmptyState`
- `EmptyState` receives `autoOpen?: boolean` prop; when true it focuses the first plugin button so the user can immediately select a plugin via keyboard
- `clearLauncherForNode` action clears the trigger after the launcher acknowledges it, preventing re-focus on remount
- New actions `clearLauncherForNode` and `setSplitAutoLaunch` are excluded from Tauri persistence via the `filterKeys` omit list

## Test plan

- [ ] CMD+D on a focused panel: new panel appears to the right and the first plugin button is focused
- [ ] CMD+Shift+D on a focused panel: new panel appears below and the first plugin button is focused
- [ ] Press Enter on the focused button immediately selects that plugin
- [ ] Clicking into the original panel (not the new one) does not trigger auto-focus
- [ ] `splitAutoLaunch: false` (set via store) suppresses the auto-focus behaviour
- [ ] Closing and reopening the app does not persist a stale `launcherOpenForNodeId`

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/107?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->