### PR TITLE
fix(plugin-bus): harden publish payload + stabilize subscribe ref (#110)

### DIFF
--- a/packages/api/src/useBusChannel.ts
+++ b/packages/api/src/useBusChannel.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { useSyncExternalStore } from "react";
 import type { PluginBus } from "./plugin";
 
@@ -12,8 +13,12 @@ export function useBusChannel<T = unknown>(
   bus: PluginBus,
   channel: string,
 ): T | undefined {
+  const subscribe = useCallback(
+    (notify: () => void) => bus.subscribe(channel, notify),
+    [bus, channel],
+  );
   return useSyncExternalStore(
-    (notify) => bus.subscribe(channel, notify),
+    subscribe,
     () => bus.read(channel) as T | undefined,
   );
 }

--- a/src/lib/pluginBus.ts
+++ b/src/lib/pluginBus.ts
@@ -7,8 +7,9 @@ const _lastValues = new Map<string, unknown>();
 
 export const pluginBus: PluginBus = {
   publish(channel, payload) {
-    _lastValues.set(channel, payload);
-    _subscribers.get(channel)?.forEach((fn) => fn(payload));
+    const frozen = Object.freeze({ ...(payload as object) }) as typeof payload;
+    _lastValues.set(channel, frozen);
+    _subscribers.get(channel)?.forEach((fn) => fn(frozen));
   },
 
   subscribe(channel, handler) {


### PR DESCRIPTION
## Summary

- `publish()` shallow-copies and `Object.freeze`s the payload before caching — prevents mutation-at-a-distance bugs where a subscriber mutates the shared cached value
- `useBusChannel` wraps the subscribe callback in `useCallback([bus, channel])` — eliminates unnecessary resubscriptions since `useSyncExternalStore` compares subscribe by reference

## Done When
- [x] `publish()` shallow-copies and `Object.freeze`s the payload before caching
- [x] `useBusChannel` wraps the subscribe callback in `useCallback([bus, channel])`
- [x] 101 tests pass

Closes #110

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/124?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->