### PR TITLE
feat(plugin-bus): typed OriginChannelMap + per-workspace bus factory (#108, #109)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,5 @@
 export type {
+  OriginChannelMap,
   PluginBus,
   PluginManifest,
   PluginContext,

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -6,7 +6,6 @@ import {
 import EmptyState from "@/components/EmptyState";
 import PluginHost from "@/components/PluginHost";
 import IframePluginHost from "@/components/IframePluginHost";
-import { pluginBus } from "@/lib/pluginBus";
 import { getPlugin } from "@/plugins/registry";
 import { cn } from "@/lib/utils";
 import { useSystemTheme } from "@/hooks/useSystemTheme";
@@ -29,6 +28,9 @@ function Card({ nodeId }: Props) {
   const launcherOpenForNodeId = useWorkspaceStore(
     (s) => s.launcherOpenForNodeId,
   );
+  // Per-workspace bus: isolates events between workspace tabs
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const bus = useWorkspaceStore((s) => s.buses[s.activeWorkspaceId])!;
 
   const pluginId = node?.type === "leaf" ? node.pluginId : null;
   const tier = pluginId ? (getPlugin(pluginId)?.tier ?? "L0") : null;
@@ -39,9 +41,9 @@ function Card({ nodeId }: Props) {
       cardId: nodeId,
       workspacePath: appDataDir,
       theme,
-      bus: pluginBus,
+      bus,
     }),
-    [nodeId, appDataDir, theme],
+    [nodeId, appDataDir, theme, bus],
   );
 
   const divRef = useRef<HTMLDivElement>(null);

--- a/src/lib/pluginBus.ts
+++ b/src/lib/pluginBus.ts
@@ -1,24 +1,34 @@
-/** Shared pub/sub bus for inter-plugin communication. */
+import type { PluginBus, OriginChannelMap } from "@origin/api";
 
-import type { PluginBus } from "@origin/api";
+/**
+ * Create a new isolated PluginBus instance.
+ * Each workspace gets its own bus so events in workspace A
+ * never fire subscribers in workspace B.
+ */
+export function createPluginBus(): PluginBus {
+  const _subscribers = new Map<string, Set<(payload: unknown) => void>>();
+  const _lastValues = new Map<string, unknown>();
 
-const _subscribers = new Map<string, Set<(payload: unknown) => void>>();
-const _lastValues = new Map<string, unknown>();
+  return {
+    publish(channel, payload) {
+      const frozen = Object.freeze({
+        ...(payload as object),
+      }) as typeof payload;
+      _lastValues.set(channel, frozen);
+      _subscribers.get(channel)?.forEach((fn) => fn(frozen));
+    },
 
-export const pluginBus: PluginBus = {
-  publish(channel, payload) {
-    const frozen = Object.freeze({ ...(payload as object) }) as typeof payload;
-    _lastValues.set(channel, frozen);
-    _subscribers.get(channel)?.forEach((fn) => fn(frozen));
-  },
+    subscribe(channel, handler) {
+      if (!_subscribers.has(channel)) _subscribers.set(channel, new Set());
+      _subscribers.get(channel)!.add(handler as (payload: unknown) => void);
+      return () =>
+        _subscribers
+          .get(channel)
+          ?.delete(handler as (payload: unknown) => void);
+    },
 
-  subscribe(channel, handler) {
-    if (!_subscribers.has(channel)) _subscribers.set(channel, new Set());
-    _subscribers.get(channel)!.add(handler);
-    return () => _subscribers.get(channel)?.delete(handler);
-  },
-
-  read(channel) {
-    return _lastValues.get(channel);
-  },
-};
+    read<K extends keyof OriginChannelMap>(channel: K) {
+      return _lastValues.get(channel) as OriginChannelMap[K] | undefined;
+    },
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
-import { tauriHandler } from "./store/workspaceStore";
+import { tauriHandler, useWorkspaceStore } from "./store/workspaceStore";
 import { initRegistry } from "./plugins/registry";
 import "./index.css";
 
 async function bootstrap() {
   await Promise.all([tauriHandler.start(), initRegistry()]);
+  // Reconstruct per-workspace buses after persisted workspaces are loaded
+  // (bus instances contain functions and are not serialized by the Tauri store)
+  useWorkspaceStore.getState().hydrateBuses();
   ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
       <App />

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,4 +1,5 @@
 export type {
+  OriginChannelMap,
   PluginManifest,
   PluginContext,
   PluginLifecycleEvent,


### PR DESCRIPTION
## Summary

- **#108**: Adds `OriginChannelMap` interface to `@origin/api`. `PluginBus.publish/subscribe/read` are now generic over `keyof OriginChannelMap`. Misspelled channel names are compile errors. Plugins extend the map via declaration merging in their own `channels.d.ts` — no central registry file needed.
- **#109**: Removes the module-level `pluginBus` singleton. Each workspace carries its own `PluginBus` instance created by `createPluginBus()`. `buses: Record<WorkspaceId, PluginBus>` lives at the store top level and is NOT persisted (not in `filterKeys`). `hydrateBuses()` reconstructs buses after `tauriHandler.start()` loads persisted workspaces.

## Done When
- [x] `PluginBus.publish/subscribe/read` are generic over `keyof OriginChannelMap` — misspelled channel names are compile errors
- [x] `pluginBus` is no longer a module-level singleton; each `Workspace` has its own `bus: PluginBus` instance
- [x] Publishing in workspace A does not fire subscribers in workspace B
- [x] `npm run typecheck` passes (pre-existing errors only), `npm test` passes (101/101)

Closes #108
Closes #109

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/125?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->