### PR TITLE
feat(api): requiredCapabilities + CHANGELOG for @origin/api (#113, #120)

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog — @origin-cards/api
+
+All notable changes to this package are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [0.4.0] — 2026-02-24
+
+Issues: #108, #109
+
+### Breaking Changes
+
+- `PluginBus.publish`, `PluginBus.subscribe`, and `PluginBus.read` are now
+  generic over `keyof OriginChannelMap`. Channel names and payload types are
+  compile-time checked; passing an unregistered channel name is a type error.
+- The module-level `pluginBus` singleton has been removed. Plugins receive a
+  workspace-scoped bus via `PluginContext.bus` (injected by `PluginHost`).
+  This prevents workspace A events from firing workspace B subscribers.
+
+### Added
+
+- `OriginChannelMap` interface — open-ended channel registry. Plugins extend it
+  via declaration merging in their own `channels.d.ts` with no central registry
+  overhead. Ships with one built-in channel: `"com.origin.app:theme-changed"`.
+- `createPluginBus()` factory function (internal use). Each `Workspace` creates
+  its own bus instance. Plugins receive the bus through `PluginContext` and
+  should not call this factory directly.
+
+---
+
+## [0.3.0] — 2026-02-24
+
+Issues: #111, #113
+
+### Breaking Changes
+
+- `CardSplit.childIds` widened from `[CardId, CardId]` tuple to `CardId[]`.
+  Consumers that destructured exactly two children must be updated.
+- `CardSplit.sizes` widened from `[number, number]` tuple to `number[]` to
+  match the n-ary `childIds` array.
+
+### Added
+
+- `PluginManifest.requiredCapabilities?: string[]` — declarative capability
+  declaration. In v0.x this is display-only (shown in the plugin install UI).
+  Enforcement by the capability broker is planned for the v1.0 marketplace
+  launch. Example values: `["fs:read", "fs:write", "dialog:open"]`.
+
+---
+
+## [0.2.0] — 2026-02-24
+
+Issue: #114
+
+### Added
+
+- `@origin/sdk` companion package — provides `usePluginContext()` and
+  `useBusChannel()` hooks for L1 (sandboxed iframe) plugins. L1 plugins run in
+  a cross-origin iframe; the SDK bridges the postMessage boundary so plugin
+  authors use the same `PluginContext` API as L0 plugins.
+- `PluginLifecycleEvent` union type — `"focus" | "blur" | "resize" | "zoom" | "zoom-exit"`.
+- `PluginContext.on(event, handler)` — subscribe to panel lifecycle events;
+  returns an unsubscribe function for use in cleanup effects.
+
+---
+
+## [0.1.0] — 2026-02-23
+
+Initial extraction of the plugin type contract from `src/types/plugin.ts` into
+a standalone `@origin-cards/api` workspace package.
+
+### Added
+
+- `PluginManifest` — `id`, `name`, `version`, `description?`, `icon?`
+- `PluginContext` — `cardId`, `workspacePath`, `theme`, `bus`
+- `PluginBus` — `publish`, `subscribe`, `read` (untyped string channels at this
+  version; typed in v0.4.0)
+- `PluginComponent` — `React.ComponentType<{ context: PluginContext }>`
+- `PluginModule` — `{ default: PluginComponent; manifest: PluginManifest }`
+- `useBusChannel` hook — convenience wrapper for `PluginBus.subscribe` that
+  handles cleanup and re-renders on channel updates
+
+---
+
+[0.4.0]: https://github.com/fellanH/origin/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/fellanH/origin/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/fellanH/origin/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/fellanH/origin/releases/tag/v0.1.0

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,0 +1,60 @@
+# @origin-cards/api
+
+Type contract for Origin plugins — `PluginManifest`, `PluginContext`,
+`PluginComponent`, `PluginModule`, `PluginBus`, and `OriginChannelMap`.
+
+Published to npm as `@origin-cards/api`.
+
+---
+
+## Installation
+
+```bash
+npm install @origin-cards/api
+```
+
+---
+
+## Usage
+
+```typescript
+import type { PluginManifest, PluginComponent, PluginModule } from "@origin-cards/api";
+
+export const manifest: PluginManifest = {
+  id: "com.example.myplugin",
+  name: "My Plugin",
+  version: "0.1.0",
+  description: "Does something useful",
+  icon: "🔧",
+  requiredCapabilities: ["fs:read"],
+};
+
+const MyPlugin: PluginComponent = ({ context }) => {
+  return <div>Hello from {context.cardId}</div>;
+};
+
+export default MyPlugin;
+```
+
+---
+
+## Versioning Policy
+
+This package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+| Change type | Version bump                               | Examples                                                                                                                                                                         |
+| ----------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MAJOR**   | Breaking changes to any exported interface | Removing or renaming fields on `PluginManifest`, `PluginContext`, `PluginBus`, `PluginComponent`, or `PluginModule`; changing method signatures in a non-backward-compatible way |
+| **MINOR**   | Additive, backward-compatible additions    | New optional fields on `PluginManifest`; new methods on `PluginBus`; new types or hooks exported from the package                                                                |
+| **PATCH**   | Non-functional changes                     | Documentation-only updates; JSDoc improvements; bug fixes that do not alter the public API shape                                                                                 |
+
+Because Origin is pre-1.0, breaking changes are permitted in MINOR bumps
+within the `0.x` series per semver convention. Each breaking change will be
+clearly labelled **BREAKING** in `CHANGELOG.md` and communicated to plugin
+authors before merge.
+
+---
+
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md) for the full version history.

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -45,6 +45,13 @@ export interface PluginManifest {
   description?: string;
   /** Emoji or relative image path shown in the Launcher grid */
   icon?: string;
+  /**
+   * Tauri capabilities this plugin uses. Declarative only in v0.x — displayed
+   * in the plugin install UI so users can see what a plugin claims to need.
+   * Enforced by the capability broker at marketplace launch (v1.0).
+   * @example ["fs:read", "fs:write", "dialog:open"]
+   */
+  requiredCapabilities?: string[];
 }
 
 /** Panel lifecycle event names emitted by PluginHost. */


### PR DESCRIPTION
## Summary
- Adds `PluginManifest.requiredCapabilities?: string[]` — declarative capability declaration (v0.x: display only; v1.0: enforced)
- Adds `packages/api/CHANGELOG.md` with full v0.1–v0.4 history
- Documents versioning policy (MAJOR/MINOR/PATCH semantics)

Closes #113
Closes #120

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/128?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->