### PR TITLE
feat(layout): N-ary childIds — support 3+ column layouts (#111)

### DIFF
--- a/src/components/workspace/WorkspaceOverlay.tsx
+++ b/src/components/workspace/WorkspaceOverlay.tsx
@@ -31,9 +31,6 @@ function MiniNode({ nodeId, nodes, focusedCardId, onSelectCard }: NodeProps) {
   if (!node) return null;
 
   if (node.type === "split") {
-    const [firstId, secondId] = node.childIds;
-    const [firstSize, secondSize] = node.sizes;
-
     return (
       <div
         className={cn(
@@ -41,28 +38,20 @@ function MiniNode({ nodeId, nodes, focusedCardId, onSelectCard }: NodeProps) {
           node.direction === "horizontal" ? "flex-row" : "flex-col",
         )}
       >
-        <div
-          style={{ flex: firstSize }}
-          className="min-h-0 min-w-0 overflow-hidden"
-        >
-          <MiniNode
-            nodeId={firstId}
-            nodes={nodes}
-            focusedCardId={focusedCardId}
-            onSelectCard={onSelectCard}
-          />
-        </div>
-        <div
-          style={{ flex: secondSize }}
-          className="min-h-0 min-w-0 overflow-hidden"
-        >
-          <MiniNode
-            nodeId={secondId}
-            nodes={nodes}
-            focusedCardId={focusedCardId}
-            onSelectCard={onSelectCard}
-          />
-        </div>
+        {node.childIds.map((childId, idx) => (
+          <div
+            key={childId}
+            style={{ flex: node.sizes[idx] ?? 1 }}
+            className="min-h-0 min-w-0 overflow-hidden"
+          >
+            <MiniNode
+              nodeId={childId}
+              nodes={nodes}
+              focusedCardId={focusedCardId}
+              onSelectCard={onSelectCard}
+            />
+          </div>
+        ))}
       </div>
     );
   }

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -12,8 +12,8 @@ export type CardSplit = {
   id: CardId;
   parentId: CardId | null;
   direction: "horizontal" | "vertical";
-  sizes: [number, number];
-  childIds: [CardId, CardId];
+  sizes: number[];
+  childIds: CardId[];
 };
 
 export type CardNode = CardLeaf | CardSplit;


### PR DESCRIPTION
## Summary

- Upgrades `CardSplit.childIds` from a binary tuple `[CardId, CardId]` to `CardId[]` and `sizes` from `[number, number]` to `number[]`
- Enables 3+ panel column/row layouts without further architectural changes
- All existing binary-split behaviour is preserved — the only structural change is type widening

## Changes

**`src/types/card.ts`**
- `CardSplit.childIds`: `[CardId, CardId]` → `CardId[]`
- `CardSplit.sizes`: `[number, number]` → `number[]`

**`src/store/workspaceStore.ts`**
- `resizeSplit` signature: `[number, number]` → `number[]`
- `splitCard`: removed `as 0 | 1` cast on `indexOf` result
- `closeCard`: N-ary path — when parent has 3+ children, splice out the closed child and its size, focus adjacent sibling; binary path (2 children) collapses the split as before
- `moveFocus`: N-ary traversal — `childIndex > 0` / `childIndex < length - 1` instead of `=== 1` / `=== 0`; sibling selected by `childIndex ± 1`
- `swapPanel`: swaps adjacent pair at `childIndex` ↔ `childIndex ± 1` (both `childIds` and `sizes` kept in sync), replacing binary `reverse()`
- `applyLayoutPreset`: switched from array destructuring to explicit index access (`[0]` / `[1]`)

**`src/components/workspace/CardTree.tsx`**
- Rewrote split rendering to use `.map()` over `node.childIds` with `<Fragment>` for N-ary panels
- `onLayoutChanged` converts `Layout` record to `number[]` via `Object.values()` before calling `resizeSplit`

**`src/components/workspace/WorkspaceOverlay.tsx`**
- `MiniNode` split branch rewritten with `.map()` over `node.childIds`

## Test plan

- [x] `npm run typecheck` — only pre-existing errors remain (App.tsx:62-64, PluginHost.tsx:55/58, workspaceStore.ts:582)
- [x] `npm test` — all 101 tests pass
- [ ] Manual: split a panel horizontally → close one child (binary collapse still works)
- [ ] Manual: split twice in same direction → close middle panel (N-ary splice path)
- [ ] Manual: keyboard focus navigation across 3+ siblings
- [ ] Manual: panel swap in a 3-panel row

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/129?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->