### PR TITLE
chore: deprecate packages/template/ in favour of origin-plugin-starter (#122)

### DIFF
--- a/docs/SOP/add-plugin.md
+++ b/docs/SOP/add-plugin.md
@@ -20,6 +20,8 @@ There are two plugin execution tiers:
 
 This SOP covers **L0 plugins**. L1 plugin authors use `@origin/sdk` (`usePluginContext`, `useBusChannel`) instead of `PluginContext` directly — they do not need to touch the core repo.
 
+> **Building a community or marketplace plugin?** Use [`origin-plugin-starter`](https://github.com/fellanH/origin-plugin-starter) — a standalone repo with full L1 build setup, TypeScript config, and live-reload dev tooling. `packages/template/` in this repo is deprecated and covers L0 only.
+
 ---
 
 ## Steps

--- a/packages/template/README.md
+++ b/packages/template/README.md
@@ -1,16 +1,23 @@
-# @origin/template — Plugin Starter
+# @origin/template — DEPRECATED
 
-Use this as the starting point for any new `@origin/*` plugin.
+> **This package is deprecated.** Use [`origin-plugin-starter`](https://github.com/fellanH/origin-plugin-starter) instead.
+>
+> `origin-plugin-starter` is the canonical starting point for new plugin authors. It includes a full build setup, TypeScript config, L1 sandbox support via `@origin/sdk`, and live-reload dev tooling.
+>
+> This in-tree template will be removed in the next major version.
 
-## Quickstart
+---
 
-1. **Copy** `plugins/template/` to `plugins/your-plugin/`
-2. **Update** `package.json` — set `"name"` to `"@origin/your-plugin"`
-3. **Edit** `src/manifest.ts` — set `id` (reverse-domain, e.g. `"com.yourco.yourplugin"`), `name`, `icon`, and `description`
-4. **Build** your component in `src/index.tsx` — default export must accept `{ context: PluginContext }`
-5. **Register** the plugin in the app:
-   - Add an entry to `origin.plugins.json`
-   - Add a literal `import()` to the `IMPORT_MAP` in `src/plugins/registry.ts`
-   - Run `npm install` to link the workspace package
+## What's here
 
-See `docs/SOP/add-plugin.md` for the full walkthrough.
+`packages/template/` is a minimal in-tree **L0 plugin skeleton** kept for reference. L0 plugins are first-party bundled plugins that run inside the main app process (no isolation). External plugin authors should use the starter repo, which produces a standalone L1 (sandboxed iframe) plugin.
+
+|          | `packages/template/`                     | `origin-plugin-starter`                 |
+| -------- | ---------------------------------------- | --------------------------------------- |
+| Tier     | L0 (bundled, in-tree)                    | L1 (sandboxed iframe)                   |
+| Status   | **Deprecated**                           | Active                                  |
+| Use when | Adding a first-party plugin to this repo | Building a community/marketplace plugin |
+
+## For first-party (L0) plugins in this repo
+
+See `docs/SOP/add-plugin.md` for the full walkthrough. L0 plugins must be registered in `src/plugins/registry.ts` and bundled at build time.

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -2,6 +2,7 @@
   "name": "@origin/template",
   "version": "0.1.0",
   "private": true,
+  "deprecated": "Use origin-plugin-starter (https://github.com/fellanH/origin-plugin-starter) for new plugins. This in-tree template will be removed in the next major version.",
   "main": "src/index.tsx",
   "types": "src/index.tsx",
   "dependencies": {


### PR DESCRIPTION
## Summary

Deprecates `packages/template/` (Option A from issue discussion):

- `packages/template/README.md` now redirects to `origin-plugin-starter` with a comparison table (L0 in-tree vs L1 community)
- `packages/template/package.json` adds `deprecated` field
- `docs/SOP/add-plugin.md` adds a callout for external/L1 plugin authors pointing to the starter repo

Template will be removed in the next major version.

Closes #122

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/131?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->