### PR TITLE
docs: macOS Ventura 13.0 minimum for v2 marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Key properties:
 - Node.js 20+
 - macOS (primary target; Tauri 2 desktop)
 
+### macOS version requirements
+
+| Feature                              | Minimum macOS        | Reason                                                     |
+| ------------------------------------ | -------------------- | ---------------------------------------------------------- |
+| Core app (v1 bundled plugins)        | macOS 10.15 Catalina | Tauri 2 minimum                                            |
+| Marketplace / community plugins (v2) | macOS 13.0 Ventura   | Import maps require WebKit 616.1 / Safari 16.4+ (Ventura+) |
+
+Users on macOS Monterey 12.x can run the app and all bundled plugins (notepad, terminal, file tree, etc.), but v2 community plugins loaded from the marketplace will silently fail to resolve — import maps are not supported in Safari < 16.4.
+
 ## Getting started
 
 ```bash

--- a/docs/SOP/add-plugin.md
+++ b/docs/SOP/add-plugin.md
@@ -13,10 +13,12 @@ Adding a new `@origin/*` plugin to the app — whether a first-party plugin or a
 
 There are two plugin execution tiers:
 
-| Tier   | Who                     | Loading                                                  | Isolation                    | Lifecycle events                         |
-| ------ | ----------------------- | -------------------------------------------------------- | ---------------------------- | ---------------------------------------- |
-| **L0** | First-party (this repo) | Build-time Vite dynamic import (static literal required) | None — runs in main app tree | Full (`focus`, `blur`, `resize`, `zoom`) |
-| **L1** | Community / marketplace | Runtime via `plugin://` URI scheme into sandboxed iframe | Null-origin iframe           | None (iframe boundary)                   |
+| Tier   | Who                     | Loading                                                  | Isolation                    | Lifecycle events                         | Minimum macOS        |
+| ------ | ----------------------- | -------------------------------------------------------- | ---------------------------- | ---------------------------------------- | -------------------- |
+| **L0** | First-party (this repo) | Build-time Vite dynamic import (static literal required) | None — runs in main app tree | Full (`focus`, `blur`, `resize`, `zoom`) | macOS 10.15 Catalina |
+| **L1** | Community / marketplace | Runtime via `plugin://` URI scheme into sandboxed iframe | Null-origin iframe           | None (iframe boundary)                   | macOS 13.0 Ventura   |
+
+> **L1 OS requirement:** L1 marketplace plugins use ES import maps injected into the WKWebView. Import maps require **WebKit 616.1 / Safari 16.4+**, which ships with **macOS Ventura 13.0**. Users on macOS Monterey 12.x will silently fail to load L1 plugins. See [issue #115](https://github.com/fellanH/origin/issues/115) and `docs/research/vite-plugin-loading.md` — WKWebView import map compatibility section.
 
 This SOP covers **L0 plugins**. L1 plugin authors use `@origin/sdk` (`usePluginContext`, `useBusChannel`) instead of `PluginContext` directly — they do not need to touch the core repo.
 

--- a/docs/research/vite-plugin-loading.md
+++ b/docs/research/vite-plugin-loading.md
@@ -46,6 +46,14 @@ Native browser feature. An import map defines `"my-plugin" → "http://localhost
 - **Vite problem:** Vite resolves all bare specifiers at build time and does not pass import maps through. Use `vite-plugin-import-maps` to inject maps into built HTML, but you lose Vite's module graph for those imports.
 - **Best fit for Tauri:** Generate import map in Rust at app startup from installed plugin metadata → inject into webview HTML before load
 
+#### WKWebView import map compatibility — macOS Ventura 13.0 minimum
+
+> **macOS version requirement (closes #115):** Import maps require **WebKit 616.1 / Safari 16.4+**, which ships with **macOS Ventura 13.0**. Users on macOS Monterey 12.x (Safari < 16.4) will silently fail to load v2 community plugins — the import map spec is present in the HTML but bare-specifier `import()` calls fall through to a 404.
+>
+> - v1 bundled plugins (build-time Vite imports) are **not affected** — they do not use import maps.
+> - A startup OS version check (`tauri::api::os::os_version()`) is a future TODO (#115) to warn Monterey users.
+> - Plugin authors targeting the marketplace must document macOS 13.0 Ventura as their minimum user requirement.
+
 ### ESM CDN (esm.sh, jspm)
 
 Not suitable for a local-first desktop app. Network dependency is a hard constraint. Only viable if self-hosting an `esm.sh` instance locally. Skip.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,11 @@ use tauri::{menu::{MenuBuilder, MenuItemBuilder}, Emitter, Manager};
 pub fn run() {
     let _ = fix_path_env::fix();
 
+    // TODO: #115 — warn users on Monterey that v2 marketplace plugins require macOS 13.0 Ventura.
+    // Import maps (used by L1 plugin loading) need WebKit 616.1 / Safari 16.4+, which ships with
+    // Ventura. On Monterey the import map is injected but bare-specifier import() falls through to
+    // a 404 silently. Use tauri::api::os::os_version() (or the tauri-plugin-os crate) to detect
+    // macOS < 13.0 at startup and emit a user-visible warning before the webview loads.
     tauri::Builder::default()
         .manage(pty::PtyManager::new())
         .plugin(tauri_plugin_updater::Builder::new().build())


### PR DESCRIPTION
## Summary

- Adds a macOS version requirements table to `README.md` documenting that v1 bundled plugins work on macOS 10.15+ while v2 marketplace/community plugins require macOS 13.0 Ventura (WebKit 616.1 / Safari 16.4+ for import map support)
- Adds a WKWebView import map compatibility note to `docs/research/vite-plugin-loading.md` explaining the Monterey silent-fail behaviour
- Updates the plugin tier table in `docs/SOP/add-plugin.md` to include a minimum macOS column and an L1 OS requirement callout for plugin authors
- Adds a `// TODO: #115` comment in `src-tauri/src/lib.rs` at the Tauri startup location marking where a future Monterey warning should be wired up

Closes #115

## Test plan

- [ ] Review README prerequisites section — macOS version table is present and accurate
- [ ] Review `docs/research/vite-plugin-loading.md` — WKWebView compatibility note appears under Import Maps section
- [ ] Review `docs/SOP/add-plugin.md` — plugin tier table now has Minimum macOS column; L1 callout block references issue #115
- [ ] Review `src-tauri/src/lib.rs` — TODO comment present above `tauri::Builder::default()`
- [ ] No build or type errors introduced (documentation-only changes; Rust comment is non-functional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/132?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->