### PR TITLE
feat: persistence crash safety (#112)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ strip = true
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-window-state = "2"
-tauri-plugin-zustand = "1"
+tauri-plugin-zustand = { version = "1", features = ["file-sync-all"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-opener = "2"

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -1,1 +1,61 @@
-// Placeholder for future filesystem commands.
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager, Runtime};
+
+/// Resolve the path to the workspace store JSON file inside app data dir.
+fn store_path<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf, String> {
+    app.path()
+        .app_data_dir()
+        .map(|d| d.join("workspace-store.json"))
+        .map_err(|e| format!("Failed to resolve app data dir: {e}"))
+}
+
+/// Copy `workspace-store.json` → `workspace-store.bak.json`.
+///
+/// Called from the JS bootstrap after `tauriHandler.start()` succeeds so that
+/// a known-good file is always preserved before the next write cycle.
+#[tauri::command]
+pub fn backup_workspace_store(app: AppHandle) -> Result<(), String> {
+    let src = store_path(&app)?;
+    if !src.exists() {
+        // Nothing to back up yet — first launch.
+        return Ok(());
+    }
+
+    let bak = src.with_extension("bak.json");
+    std::fs::copy(&src, &bak).map_err(|e| format!("backup_workspace_store failed: {e}"))?;
+    Ok(())
+}
+
+/// Validate `workspace-store.json`. If it is missing or contains invalid JSON,
+/// attempt to restore from `workspace-store.bak.json`.
+///
+/// Returns `"ok"`, `"recovered"`, or `"no-backup"` so the caller can log which
+/// path was taken.
+#[tauri::command]
+pub fn recover_workspace_store(app: AppHandle) -> Result<String, String> {
+    let src = store_path(&app)?;
+    let bak = src.with_extension("bak.json");
+
+    let needs_recovery = if src.exists() {
+        // Consider the file corrupt if it cannot be read or is not valid JSON.
+        match std::fs::read_to_string(&src) {
+            Ok(content) => serde_json::from_str::<serde_json::Value>(&content).is_err(),
+            Err(_) => true,
+        }
+    } else {
+        // File does not exist — first launch. Nothing to recover.
+        return Ok("ok".to_string());
+    };
+
+    if !needs_recovery {
+        return Ok("ok".to_string());
+    }
+
+    if bak.exists() {
+        std::fs::copy(&bak, &src)
+            .map_err(|e| format!("recover_workspace_store: copy bak failed: {e}"))?;
+        Ok("recovered".to_string())
+    } else {
+        Ok("no-backup".to_string())
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,8 @@ pub fn run() {
             }
         })
         .invoke_handler(tauri::generate_handler![
+            commands::fs::backup_workspace_store,
+            commands::fs::recover_workspace_store,
             commands::plugins::list_installed_plugins,
             commands::plugins::install_plugin,
             commands::plugins::restart_app,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,15 +1,43 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { invoke } from "@tauri-apps/api/core";
 import App from "./App";
 import { tauriHandler, useWorkspaceStore } from "./store/workspaceStore";
 import { initRegistry } from "./plugins/registry";
 import "./index.css";
 
 async function bootstrap() {
+  // --- Crash safety: recover from backup before loading persisted state ----
+  // If workspace-store.json is missing or contains invalid JSON, this command
+  // replaces it with the last known-good .bak.json (if one exists).
+  const recoveryResult = await invoke<string>("recover_workspace_store").catch(
+    (err) => {
+      console.warn("[store] recover_workspace_store failed:", err);
+      return "ok";
+    },
+  );
+  if (recoveryResult === "recovered") {
+    console.info("[store] Restored workspace-store.json from backup.");
+  } else if (recoveryResult === "no-backup") {
+    console.warn(
+      "[store] Workspace store corrupt and no backup available — starting fresh.",
+    );
+  }
+
+  // Load persisted state from (possibly just-recovered) file.
   await Promise.all([tauriHandler.start(), initRegistry()]);
+
   // Reconstruct per-workspace buses after persisted workspaces are loaded
   // (bus instances contain functions and are not serialized by the Tauri store)
   useWorkspaceStore.getState().hydrateBuses();
+
+  // --- Crash safety: write backup of the freshly-loaded good state ----------
+  // This runs async in the background — we don't await it so it doesn't block
+  // the initial render.
+  invoke<void>("backup_workspace_store").catch((err) => {
+    console.warn("[store] backup_workspace_store failed:", err);
+  });
+
   ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
       <App />

--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -11,6 +11,12 @@ import { panelRefs } from "@/lib/panelRefs";
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 type WorkspaceState = {
+  /**
+   * Schema version for the persisted JSON shape.
+   * - undefined / missing: treated as v0 (pre-versioning; no migration required yet)
+   * - 1: current shape (added in #112)
+   */
+  version: 1;
   workspaces: Workspace[];
   activeWorkspaceId: WorkspaceId;
   /** Workspace that was active before the current one; enables CMD+Opt+Tab toggle */
@@ -103,6 +109,7 @@ const INITIAL_ID: WorkspaceId = "default";
 export const useWorkspaceStore = create<WorkspaceStore>()(
   devtools(
     immer((set) => ({
+      version: 1,
       workspaces: [emptyWorkspace(INITIAL_ID, "Workspace 1")],
       activeWorkspaceId: INITIAL_ID,
       lastWorkspaceId: null,
@@ -574,6 +581,7 @@ export const tauriHandler = createTauriStore(
   useWorkspaceStore as any,
   {
     filterKeys: [
+      "version",
       "workspaces",
       "activeWorkspaceId",
       "lastWorkspaceId",


### PR DESCRIPTION
## Summary

- **Part 1 — file-sync-all**: Enables the `file-sync-all` Cargo feature on `tauri-plugin-zustand` v1 (confirmed valid on v1.2.0 via docs.rs). Forces `fsync()` after every write, preventing truncated JSON files when the kernel buffer is not flushed before a crash.
- **Part 2 — backup/recovery**: Two new Rust commands in `src-tauri/src/commands/fs.rs`:
  - `recover_workspace_store` — called in `main.tsx` _before_ `tauriHandler.start()`. Validates `workspace-store.json`; if corrupt or unreadable, copies `workspace-store.bak.json` over it and returns `"recovered"`. Returns `"no-backup"` if neither file is healthy. Safe to call on first launch (no-op).
  - `backup_workspace_store` — called in `main.tsx` _after_ hydration completes (fire-and-forget). Copies the known-good `workspace-store.json` to `workspace-store.bak.json`.
- **Part 3 — version field**: Adds `version: 1` to `WorkspaceState` type and initial state. The field is included in `filterKeys` so it is written to disk. A missing `version` field in an existing file is treated as v0 (pre-#112); no migration logic is needed at this schema level.

## Test plan

- [ ] First launch: no `.bak` file is created until after the first successful load cycle
- [ ] Normal launch: `workspace-store.bak.json` appears in `$APPDATA/com.klarhimmel.origin/` after startup
- [ ] Corrupt-store recovery: manually truncate `workspace-store.json` to `{`, restart — app recovers from `.bak` and logs `[store] Restored workspace-store.json from backup.`
- [ ] No-backup path: delete both files, corrupt just the main file, restart — app logs `[store] Workspace store corrupt and no backup available — starting fresh.` and starts with default state
- [ ] `tsc --noEmit` passes with no new errors (pre-existing errors in App.tsx / PluginHost.tsx / filterKeysStrategy remain unchanged)

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/133?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->