### PR TITLE
chore: remove stale plugins/ directory

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -4,9 +4,9 @@ A curated list of plugins built for [Origin](https://github.com/fellanH/origin).
 
 ## Official
 
-| Plugin                                                             | Description                                                       |
-| ------------------------------------------------------------------ | ----------------------------------------------------------------- |
-| [hello](https://github.com/fellanH/origin/tree/main/plugins/hello) | Reference plugin — demonstrates the full plugin API with comments |
+| Plugin                                                              | Description                                                       |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [hello](https://github.com/fellanH/origin/tree/main/packages/hello) | Reference plugin — demonstrates the full plugin API with comments |
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ npm run tauri build
 ```
 src/          React 19 frontend (components, store, plugins, types)
 src-tauri/    Rust/Tauri backend (commands, capabilities, config)
-plugins/      @origin/* plugin packages (npm workspaces)
+packages/     @origin/* plugin packages (npm workspaces)
   api/        @origin/api — plugin type contract (PluginManifest, PluginContext)
   hello/      @origin/hello — reference plugin implementation
-  template/   @origin/template — scaffold for new plugin authors
+  template/   @origin/template — scaffold for new plugin authors (deprecated)
 docs/         Spec, research, SOPs, standards
 ```
 
@@ -60,7 +60,7 @@ docs/         Spec, research, SOPs, standards
 
 ## Plugin system
 
-Plugins are npm workspace packages under `plugins/`. Each plugin:
+Plugins are npm workspace packages under `packages/`. Each plugin:
 
 - Depends on `@origin/api` for type contracts (`PluginManifest`, `PluginContext`)
 - Exports a `manifest` and a default React component
@@ -79,7 +79,7 @@ To build your own plugin, start from the [origin-plugin-starter](https://github.
 | Styling      | Tailwind CSS 4 + shadcn/ui          | v4 only — breaking changes from v3                             |
 | Panel layout | `react-resizable-panels` v4         | v4 renames several APIs                                        |
 | State        | Zustand v5 + `@tauri-store/zustand` | File-backed; not localStorage                                  |
-| Build        | Vite 7, npm workspaces              | Plugins in `plugins/`                                          |
+| Build        | Vite 7, npm workspaces              | Plugins in `packages/`                                         |
 
 ## Documentation
 

--- a/docs/GOALS.md
+++ b/docs/GOALS.md
@@ -23,7 +23,7 @@ should be an Origin plugin. The goal is 50+ quality community plugins.
 
 **3. Exceptional plugin author DX**
 Writing a plugin should feel like writing a React component — because it is.
-`@origin/api` provides the contract. `plugins/template` provides the scaffold.
+`@origin/api` provides the contract. `packages/template` provides the scaffold.
 The SOP gets you from zero to running in under 10 minutes. If that's not
 true, it's a bug.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -339,7 +339,7 @@ interface PluginModule {
 }
 ```
 
-Plugins are npm workspace packages. `@origin/hello` resolves to `plugins/hello/` via workspaces. Vite dynamic `import('@origin/hello')` works in both dev and prod (bundled at build time).
+Plugins are npm workspace packages. `@origin/hello` resolves to `packages/hello/` via workspaces. Vite dynamic `import('@origin/hello')` works in both dev and prod (bundled at build time).
 
 > **Two-tier plugin system:**
 >
@@ -381,7 +381,7 @@ origin/
 │       ├── PluginHost.tsx      # L0: loads + mounts a plugin component with PluginContext; wrapped in ErrorBoundary
 │       ├── IframePluginHost.tsx # L1: sandboxed iframe host with postMessage protocol + bus relay
 │       └── EmptyState.tsx      # Unified empty slot: name + keyboard hints + plugin list; optional cardId prop
-├── plugins/
+├── packages/
 │   ├── api/
 │   │   └── src/plugin.ts       # Type contract: PluginManifest, PluginContext, PluginBus, PluginModule
 │   ├── sdk/
@@ -392,7 +392,7 @@ origin/
 │           ├── manifest.ts     # PluginManifest export
 │           └── index.tsx       # default export: React component
 ├── origin.plugins.json
-├── package.json                # workspaces: ["plugins/*"]
+├── package.json                # workspaces: ["packages/*"]
 ├── vite.config.ts
 ├── tsconfig.json
 └── tailwind.config.ts
@@ -615,7 +615,7 @@ Do not use `unsafe-eval`. The `plugin:` entry is required for L1 iframe plugin s
 8. **Plugin registry + loader** — reads `origin.plugins.json`, dynamic import cache
 9. **PluginHost** — loads module, injects `PluginContext`, renders component inside Error Boundary
 10. **Keyboard shortcuts** — global `keydown` listener in `App.tsx` with `event.preventDefault()`; handlers read `focusedPanelId` from store. `tauri-plugin-global-shortcut` is NOT used (in-window shortcuts work via webview keydown). Register `onCloseRequested` on the Tauri window to prevent accidental window close.
-11. **Hello plugin** — `plugins/hello/` minimal React component with manifest
+11. **Hello plugin** — `packages/hello/` minimal React component with manifest
 12. **Wire it up** — npm workspaces, verify `@origin/hello` resolves, end-to-end test
 
 ---
@@ -633,12 +633,12 @@ Do not use `unsafe-eval`. The `plugin:` entry is required for L1 iframe plugin s
 | `src/components/PluginHost.tsx`       | L0 host — direct React mount, full `PluginContext` including `on()` lifecycle events     |
 | `src/components/IframePluginHost.tsx` | L1 host — sandboxed iframe, postMessage handshake, bus relay, theme forwarding           |
 | `src/lib/iframeProtocol.ts`           | Typed postMessage schema (`HostToPluginMessage`, `PluginToHostMessage`)                  |
-| `plugins/sdk/src/`                    | `@origin/sdk`: `usePluginContext()` + `useBusChannel()` for L1 plugin authors            |
+| `packages/sdk/src/`                   | `@origin/sdk`: `usePluginContext()` + `useBusChannel()` for L1 plugin authors            |
 | `src/components/TabBar.tsx`           | Tab strip — workspace switching + new/close tab                                          |
 | `src/components/SavedConfigMenu.tsx`  | Save/load/delete named layout configs                                                    |
 | `src/components/PanelGrid.tsx`        | Root component — starts the render tree                                                  |
 | `src/components/EmptyState.tsx`       | Unified empty slot — rendered at workspace level (no panels) and panel level (no plugin) |
-| `plugins/hello/src/index.tsx`         | PoC plugin — verifies the plugin system works                                            |
+| `packages/hello/src/index.tsx`        | PoC plugin — verifies the plugin system works                                            |
 | `origin.plugins.json`                 | Plugin config — single source of truth for registered plugins                            |
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -7649,6 +7649,7 @@
     "packages/template": {
       "name": "@origin/template",
       "version": "0.1.0",
+      "deprecated": "Use origin-plugin-starter (https://github.com/fellanH/origin-plugin-starter) for new plugins. This in-tree template will be removed in the next major version.",
       "dependencies": {
         "@origin/api": "*"
       }

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -4,7 +4,7 @@ Use this as the starting point for any new `@origin/*` plugin.
 
 ## Quickstart
 
-1. **Copy** `plugins/template/` to `plugins/your-plugin/`
+1. **Copy** `packages/template/` to `packages/your-plugin/`
 2. **Update** `package.json` — set `"name"` to `"@origin/your-plugin"`
 3. **Edit** `src/manifest.ts` — set `id` (reverse-domain, e.g. `"com.yourco.yourplugin"`), `name`, `icon`, and `description`
 4. **Build** your component in `src/index.tsx` — default export must accept `{ context: PluginContext }`

--- a/packages/notepad/README.md
+++ b/packages/notepad/README.md
@@ -4,7 +4,7 @@ Use this as the starting point for any new `@origin/*` plugin.
 
 ## Quickstart
 
-1. **Copy** `plugins/template/` to `plugins/your-plugin/`
+1. **Copy** `packages/template/` to `packages/your-plugin/`
 2. **Update** `package.json` — set `"name"` to `"@origin/your-plugin"`
 3. **Edit** `src/manifest.ts` — set `id` (reverse-domain, e.g. `"com.yourco.yourplugin"`), `name`, `icon`, and `description`
 4. **Build** your component in `src/index.tsx` — default export must accept `{ context: PluginContext }`

--- a/plugins/api/typedoc.json
+++ b/plugins/api/typedoc.json
@@ -1,8 +1,0 @@
-{
-  "entryPoints": ["src/index.ts"],
-  "tsconfig": "tsconfig.json",
-  "json": "dist/api-docs.json",
-  "readme": "none",
-  "excludeInternal": true,
-  "skipErrorChecking": true
-}


### PR DESCRIPTION
## Summary

- Deletes `plugins/api/typedoc.json` — the only remaining file in the `plugins/` directory (a stale TypeDoc config artifact from before the rename in #117)
- Updates all active docs (`README.md`, `PLUGINS.md`, `docs/SPEC.md`, `docs/GOALS.md`, `packages/github/README.md`, `packages/notepad/README.md`) to reference `packages/` instead of `plugins/`
- `package.json` workspaces was already `["packages/*"]` — this removes the last stale artifact and makes the repo consistent

Historical research docs (`docs/research/`, `docs/plans/`, `docs/archive/`, `docs/SOP/scaffold.md`) intentionally preserve their `plugins/` examples as they document the pre-rename project state.

## Test plan

- [x] `plugins/` directory is fully gone
- [x] `npm install` completes cleanly (workspace links verified)
- [x] `tsc --noEmit` produces no new errors (pre-existing errors unchanged)
- [x] All active docs updated — no broken `plugins/` workspace directory references remain

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/134?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->