### PR TITLE
fix(card): stabilise leaf keys on adjacent panel split

### DIFF
--- a/src/components/workspace/CardTree.tsx
+++ b/src/components/workspace/CardTree.tsx
@@ -23,7 +23,10 @@ function CardTree({ nodeId }: Props) {
   if (!node) return null;
 
   if (node.type === "leaf") {
-    return <Card nodeId={nodeId} />;
+    // key={nodeId} ensures React preserves this component instance (and all
+    // plugin state inside it) when an adjacent panel splits and the surrounding
+    // PanelGroup/ResizablePanel tree is restructured around this leaf.
+    return <Card key={nodeId} nodeId={nodeId} />;
   }
 
   // node.type === "split" — N-ary children


### PR DESCRIPTION
## Summary

- Adds `key={nodeId}` to the `<Card>` rendered in `CardTree`'s leaf branch — one-line fix that prevents React from remounting plugin components when an adjacent panel splits
- Documents the root cause and both fix patterns in `docs/STANDARDS.md` under a new **Plugin State Preservation** section

## Root cause

When `splitCard(cardId, direction)` runs, a new intermediate `split` node is inserted and the surrounding `<ResizablePanel>` hierarchy reshapes. Without a stable `key`, React reconciles `<Card>` by tree position and **remounts** it — wiping all plugin state (open file, current URL, terminal session, expanded tree nodes).

`nodeId` is a stable UUID for the lifetime of that card, so `key={nodeId}` lets React reuse the existing component instance even as the panel wrappers restructure around it.

## Files changed

| File | Change |
|---|---|
| `src/components/workspace/CardTree.tsx` | `<Card key={nodeId} nodeId={nodeId} />` on the leaf branch |
| `docs/STANDARDS.md` | New "Plugin State Preservation" section |

## Why no plugin-side changes needed

The module-level cache in `notepad` was a belt-and-suspenders measure (it also provides an instant paint on remount and flushes unsaved edits). With the stable key, terminal, monaco, browser, filetree, and github retain their React state without any changes to those packages.

## Test plan

- [ ] Open a Monaco editor and load a file; split an adjacent panel — Monaco retains the open file
- [ ] Open a Browser plugin at a non-default URL; split an adjacent panel — URL bar still shows the navigated URL
- [ ] Open a terminal and type some output; split an adjacent panel — terminal session is preserved
- [ ] Open a FileTree and expand some directories; split an adjacent panel — expanded paths remain
- [ ] Open GitHub plugin configured to a repo; split an adjacent panel — PR list remains visible
- [ ] Confirm notepad still works (its module-level cache path is unaffected by this change)
- [ ] `npm run typecheck` passes with no new errors

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/159?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->