### PR TITLE
feat: settings panel with CMD+, shortcut (#137)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,9 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import CardLayout from "@/components/workspace/CardLayout";
 import TabBar from "@/components/workspace/TabBar";
 import WorkspaceOverlay from "@/components/workspace/WorkspaceOverlay";
+import SettingsPanel, {
+  type ThemePreference,
+} from "@/components/settings/SettingsPanel";
 
 function App() {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
@@ -16,12 +19,25 @@ function App() {
   const setFocus = useWorkspaceStore((s) => s.setFocus);
 
   const [showOverlay, setShowOverlay] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const [theme, setTheme] = useState<ThemePreference>("system");
 
-  useKeyboardShortcuts();
+  useKeyboardShortcuts({ onToggleSettings: () => setShowSettings((p) => !p) });
 
   useEffect(() => {
     appDataDir().then(setAppDataDir);
   }, [setAppDataDir]);
+
+  // Apply theme class to <html> whenever the preference changes.
+  // "system" removes the manual override so prefers-color-scheme takes effect.
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+  }, [theme]);
 
   // CMD+Opt+G — toggle workspace overview HUD
   useEffect(() => {
@@ -52,7 +68,7 @@ function App() {
 
   return (
     <div className="flex h-screen flex-col">
-      <TabBar />
+      <TabBar onOpenSettings={() => setShowSettings(true)} />
       <div className="flex-1 overflow-hidden">
         <CardLayout key={activeWorkspaceId} />
       </div>
@@ -66,6 +82,13 @@ function App() {
           onClose={() => setShowOverlay(false)}
         />
       )}
+
+      <SettingsPanel
+        open={showSettings}
+        theme={theme}
+        onClose={() => setShowSettings(false)}
+        onThemeChange={setTheme}
+      />
     </div>
   );
 }

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useRef } from "react";
+import { useWorkspaceStore } from "@/store/workspaceStore";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ThemePreference = "system" | "light" | "dark";
+
+type SettingsPanelProps = {
+  open: boolean;
+  theme: ThemePreference;
+  onClose: () => void;
+  onThemeChange: (theme: ThemePreference) => void;
+};
+
+// ─── Section ─────────────────────────────────────────────────────────────────
+
+type SectionProps = {
+  title: string;
+  disabled?: boolean;
+  children: React.ReactNode;
+};
+
+function Section({ title, disabled = false, children }: SectionProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <h3
+        className={cn(
+          "text-[11px] font-semibold uppercase tracking-widest",
+          disabled ? "text-muted-foreground/40" : "text-muted-foreground",
+        )}
+      >
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+// ─── Row ──────────────────────────────────────────────────────────────────────
+
+type RowProps = {
+  label: string;
+  description?: string;
+  children: React.ReactNode;
+};
+
+function Row({ label, description, children }: RowProps) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-sm leading-none">{label}</span>
+        {description && (
+          <span className="text-[11px] leading-snug text-muted-foreground">
+            {description}
+          </span>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ─── Toggle ──────────────────────────────────────────────────────────────────
+
+type ToggleProps = {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+};
+
+function Toggle({ checked, onChange, label }: ToggleProps) {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onChange(!checked)}
+      className={cn(
+        "relative h-5 w-9 shrink-0 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+        checked ? "bg-foreground" : "bg-foreground/20",
+      )}
+    >
+      <span
+        className={cn(
+          "absolute top-0.5 h-4 w-4 rounded-full bg-background shadow-sm transition-transform",
+          checked ? "left-[calc(100%-18px)]" : "left-0.5",
+        )}
+      />
+    </button>
+  );
+}
+
+// ─── ThemeSelector ───────────────────────────────────────────────────────────
+
+const THEME_OPTIONS: { value: ThemePreference; label: string }[] = [
+  { value: "system", label: "System" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+];
+
+type ThemeSelectorProps = {
+  value: ThemePreference;
+  onChange: (v: ThemePreference) => void;
+};
+
+function ThemeSelector({ value, onChange }: ThemeSelectorProps) {
+  return (
+    <div className="flex overflow-hidden rounded-md border border-border">
+      {THEME_OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          className={cn(
+            "px-3 py-1 text-xs transition-colors",
+            value === opt.value
+              ? "bg-foreground text-background"
+              : "bg-transparent text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ─── SettingsPanel ────────────────────────────────────────────────────────────
+
+export default function SettingsPanel({
+  open,
+  theme,
+  onClose,
+  onThemeChange,
+}: SettingsPanelProps) {
+  const splitAutoLaunch = useWorkspaceStore((s) => s.splitAutoLaunch);
+  const setSplitAutoLaunch = useWorkspaceStore((s) => s.setSplitAutoLaunch);
+
+  // Close on Escape
+  const panelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    function handleKeyDown(e: KeyboardEvent): void {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  return (
+    <>
+      {/* Transparent backdrop — click-away dismissal */}
+      {open && (
+        <div
+          className="fixed inset-0 z-40"
+          aria-hidden="true"
+          onClick={onClose}
+        />
+      )}
+
+      {/* Slide-over panel — overlays from the right, does not shift content */}
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Settings"
+        className={cn(
+          "fixed right-0 top-0 z-50 flex h-screen w-[320px] flex-col border-l border-border bg-background shadow-xl",
+          "transition-transform duration-200 ease-in-out",
+          open ? "translate-x-0" : "translate-x-full",
+        )}
+      >
+        {/* Header — matches TabBar height */}
+        <div className="flex h-[38px] shrink-0 items-center justify-between border-b border-border px-4">
+          <span className="text-sm font-semibold">Settings</span>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onClose}
+            aria-label="Close settings"
+            className="opacity-60 hover:opacity-100"
+          >
+            ×
+          </Button>
+        </div>
+
+        {/* Body */}
+        <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-4 py-5">
+          {/* Appearance */}
+          <Section title="Appearance">
+            <Row label="Theme" description="Controls the colour scheme">
+              <ThemeSelector value={theme} onChange={onThemeChange} />
+            </Row>
+          </Section>
+
+          <div className="border-t border-border" />
+
+          {/* Behaviour */}
+          <Section title="Behaviour">
+            <Row
+              label="Auto-open launcher on split"
+              description="Opens the plugin picker in each new panel"
+            >
+              <Toggle
+                checked={splitAutoLaunch}
+                onChange={setSplitAutoLaunch}
+                label="Auto-open launcher on split"
+              />
+            </Row>
+          </Section>
+
+          <div className="border-t border-border" />
+
+          {/* Sync — placeholder */}
+          <Section title="Sync (coming soon)" disabled>
+            <p className="text-xs text-muted-foreground/50">
+              Sync settings will be available in a future release.
+            </p>
+          </Section>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/workspace/TabBar.tsx
+++ b/src/components/workspace/TabBar.tsx
@@ -3,7 +3,11 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useWorkspaceStore } from "@/store/workspaceStore";
 import { cn } from "@/lib/utils";
 
-export default function TabBar() {
+type TabBarProps = {
+  onOpenSettings: () => void;
+};
+
+export default function TabBar({ onOpenSettings }: TabBarProps) {
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const addWorkspace = useWorkspaceStore((s) => s.addWorkspace);
@@ -106,6 +110,20 @@ export default function TabBar() {
       </button>
 
       <div className="flex-1 self-stretch" />
+
+      {/* Settings gear — far right, stops drag propagation */}
+      <button
+        tabIndex={-1}
+        aria-label="Open settings"
+        className="flex h-full select-none items-center px-2 text-sm opacity-50 hover:opacity-100"
+        onClick={(e) => {
+          e.stopPropagation();
+          onOpenSettings();
+        }}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        ⚙
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds `SettingsPanel` — a 320px slide-over from the right that overlays content without shifting the layout
- **Appearance** section: System / Light / Dark theme toggle that writes the `.dark` class on `<html>` using CSS variable–based theming (not persisted, ephemeral `useState`)
- **Behaviour** section: "Auto-open launcher on split" toggle wired to `splitAutoLaunch` in `workspaceStore`
- **Sync** section: placeholder, greyed-out header — no functionality
- Gear icon (⚙) added to the far right of `TabBar`, stops drag propagation correctly
- `CMD+,` keyboard shortcut toggles the panel, added to `useKeyboardShortcuts` via a stable `useRef` callback pattern (avoids re-registering the listener on every render while keeping the callback fresh)

## Test plan

- [ ] Click the ⚙ gear icon in the tab bar — settings panel slides in from right
- [ ] Press `CMD+,` — panel opens; press again — panel closes
- [ ] Press `Escape` while panel is open — panel closes
- [ ] Click outside the panel (backdrop) — panel closes
- [ ] Theme toggle: click Light / Dark / System — verify `<html>` class changes and UI responds
- [ ] Behaviour toggle: verify "Auto-open launcher on split" reflects and updates store state
- [ ] Panel does not shift main content — overlays only
- [ ] Traffic lights and tab bar alignment unaffected
- [ ] `npm run typecheck` passes with no new errors

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/160?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->