### PR TITLE
feat: plugin per-instance config — CardLeaf.config + PluginContext.setConfig

### DIFF
--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -15,6 +15,17 @@ import type React from "react";
 export interface OriginChannelMap {
   /** Fired whenever the system theme switches. */
   "com.origin.app:theme-changed": { theme: "light" | "dark" };
+  /**
+   * Fired when the active path changes in the workspace — e.g. a file is
+   * selected in FileTree. Monaco (and any other subscriber) opens the path.
+   */
+  "origin:workspace/active-path": {
+    /** Absolute filesystem path. */
+    path: string;
+    type: "file" | "directory";
+    /** Plugin ID of the publisher, e.g. "com.origin.filetree". */
+    source: string;
+  };
 }
 
 /** Pub/sub bus injected into every plugin via PluginContext. */
@@ -72,6 +83,21 @@ export interface PluginContext {
   theme: "light" | "dark";
   /** Inter-plugin communication bus scoped to this workspace */
   bus: PluginBus;
+  /**
+   * Per-instance plugin configuration. Persisted alongside the card in the
+   * workspace store. Use setConfig to update — changes are shallow-merged.
+   *
+   * @example
+   * const url = (context.config.url as string) ?? "http://localhost:3000";
+   */
+  config: Record<string, unknown>;
+  /**
+   * Shallow-merge a patch into this card's config. Persisted automatically.
+   *
+   * @example
+   * context.setConfig({ url: "http://localhost:4000" });
+   */
+  setConfig: (patch: Record<string, unknown>) => void;
   /**
    * Subscribe to a panel lifecycle event.
    * Returns an unsubscribe function — call it in your plugin's cleanup.

--- a/packages/sdk/src/context.ts
+++ b/packages/sdk/src/context.ts
@@ -1,15 +1,26 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import type {
   IframePluginContext,
   HostToPluginMessage,
 } from "@/lib/iframeProtocol";
 
 /**
+ * Extended context type returned by usePluginContext.
+ * Adds a setConfig helper that sends ORIGIN_CONFIG_SET to the host.
+ */
+export interface IframePluginContextWithConfig extends IframePluginContext {
+  setConfig: (patch: Record<string, unknown>) => void;
+}
+
+/**
  * Returns the plugin context injected by the host via postMessage.
  * Returns null until the ORIGIN_INIT message is received.
  * Automatically posts ORIGIN_READY on mount.
+ *
+ * The returned object includes a stable `setConfig` function that sends a
+ * shallow config patch to the host, which persists it in the workspace store.
  */
-export function usePluginContext(): IframePluginContext | null {
+export function usePluginContext(): IframePluginContextWithConfig | null {
   const [context, setContext] = useState<IframePluginContext | null>(null);
 
   useEffect(() => {
@@ -19,6 +30,8 @@ export function usePluginContext(): IframePluginContext | null {
         setContext(msg.context);
       } else if (msg.type === "ORIGIN_THEME_CHANGE") {
         setContext((prev) => (prev ? { ...prev, theme: msg.theme } : prev));
+      } else if (msg.type === "ORIGIN_CONFIG_UPDATE") {
+        setContext((prev) => (prev ? { ...prev, config: msg.config } : prev));
       }
     }
 
@@ -28,5 +41,10 @@ export function usePluginContext(): IframePluginContext | null {
     return () => window.removeEventListener("message", onMessage);
   }, []);
 
-  return context;
+  const setConfig = useCallback((patch: Record<string, unknown>) => {
+    window.parent.postMessage({ type: "ORIGIN_CONFIG_SET", patch }, "*");
+  }, []);
+
+  if (!context) return null;
+  return { ...context, setConfig };
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,3 +1,4 @@
 export { usePluginContext } from "./context";
+export type { IframePluginContextWithConfig } from "./context";
 export { useBusChannel } from "./bus";
 export type { IframePluginContext } from "@/lib/iframeProtocol";

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::fs::backup_workspace_store,
             commands::fs::recover_workspace_store,
+            commands::fs::migrate_store_path,
             commands::plugins::list_installed_plugins,
             commands::plugins::install_plugin,
             commands::plugins::restart_app,

--- a/src/components/card/IframePluginHost.tsx
+++ b/src/components/card/IframePluginHost.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 function IframePluginHostInner({ pluginId, context, manifest }: Props) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  // Track whether ORIGIN_READY has been received so theme updates can be forwarded
+  // Track whether ORIGIN_READY has been received so theme/config updates can be forwarded
   const readyRef = useRef(false);
   // Map of channel → unsubscribe fn for channels the plugin has subscribed to
   const channelUnsubs = useRef(new Map<string, () => void>());
@@ -44,17 +44,15 @@ function IframePluginHostInner({ pluginId, context, manifest }: Props) {
             cardId: context.cardId,
             workspacePath: context.workspacePath,
             theme: context.theme,
+            config: context.config,
           },
         });
       } else if (msg.type === "ORIGIN_BUS_PUBLISH") {
-        // Cast dynamic iframe channel to typed key — safe because the bus
-        // implementation accepts any string; this is the iframe trust boundary.
         context.bus.publish(
           msg.channel as keyof OriginChannelMap,
           msg.payload as OriginChannelMap[keyof OriginChannelMap],
         );
       } else if (msg.type === "ORIGIN_BUS_SUBSCRIBE") {
-        // Avoid double-subscribe if plugin re-subscribes
         if (channelUnsubs.current.has(msg.channel)) return;
         const unsub = context.bus.subscribe(
           msg.channel as keyof OriginChannelMap,
@@ -79,42 +77,32 @@ function IframePluginHostInner({ pluginId, context, manifest }: Props) {
         // 1. Command must be in the allow-list
         const requiredCap = COMMAND_CAPABILITY_MAP[command];
         if (requiredCap === undefined) {
-          postToPlugin({
-            type: "ORIGIN_INVOKE_ERROR",
-            id,
-            error: `Command not allowed: ${command}`,
-          });
+          postToPlugin({ type: "ORIGIN_INVOKE_ERROR", id, error: `Command not allowed: ${command}` });
           return;
         }
 
         // 2. Plugin manifest must declare the required capability
         const declared = manifestRef.current?.requiredCapabilities ?? [];
         if (!declared.includes(requiredCap)) {
-          postToPlugin({
-            type: "ORIGIN_INVOKE_ERROR",
-            id,
-            error: `Missing capability: ${requiredCap}`,
-          });
+          postToPlugin({ type: "ORIGIN_INVOKE_ERROR", id, error: `Missing capability: ${requiredCap}` });
           return;
         }
 
         // 3. Proxy the call through Tauri — failures must not crash the host
         invoke(command, args)
-          .then((result) => {
-            postToPlugin({ type: "ORIGIN_INVOKE_RESULT", id, result });
-          })
+          .then((result) => postToPlugin({ type: "ORIGIN_INVOKE_RESULT", id, result }))
           .catch((err: unknown) => {
-            const error =
-              err instanceof Error ? err.message : String(err);
-            postToPlugin({ type: "ORIGIN_INVOKE_ERROR", id, error });
+            postToPlugin({ type: "ORIGIN_INVOKE_ERROR", id, error: err instanceof Error ? err.message : String(err) });
           });
+      } else if (msg.type === "ORIGIN_CONFIG_SET") {
+        // Plugin requests a config patch — delegate to store via context
+        context.setConfig(msg.patch);
       }
     }
 
     window.addEventListener("message", onMessage);
     return () => {
       window.removeEventListener("message", onMessage);
-      // Clean up all bus subscriptions
       channelUnsubs.current.forEach((unsub) => unsub());
       channelUnsubs.current.clear();
       readyRef.current = false;
@@ -124,6 +112,7 @@ function IframePluginHostInner({ pluginId, context, manifest }: Props) {
     context.cardId,
     context.workspacePath,
     context.bus,
+    context.setConfig,
     postToPlugin,
   ]);
 
@@ -132,6 +121,12 @@ function IframePluginHostInner({ pluginId, context, manifest }: Props) {
     if (!readyRef.current) return;
     postToPlugin({ type: "ORIGIN_THEME_CHANGE", theme: context.theme });
   }, [context.theme, postToPlugin]);
+
+  // Forward config changes from the store to the iframe after READY
+  useEffect(() => {
+    if (!readyRef.current) return;
+    postToPlugin({ type: "ORIGIN_CONFIG_UPDATE", config: context.config });
+  }, [context.config, postToPlugin]);
 
   return (
     <iframe

--- a/src/lib/iframeProtocol.ts
+++ b/src/lib/iframeProtocol.ts
@@ -5,7 +5,11 @@ export type HostToPluginMessage =
   | { type: "ORIGIN_BUS_EVENT"; channel: string; payload: unknown }
   | { type: "ORIGIN_THEME_CHANGE"; theme: "light" | "dark" }
   | { type: "ORIGIN_INVOKE_RESULT"; id: string; result: unknown }
-  | { type: "ORIGIN_INVOKE_ERROR"; id: string; error: string };
+  | { type: "ORIGIN_INVOKE_ERROR"; id: string; error: string }
+  /** Sent when the host detects an external config change (e.g. another tab). */
+  | { type: "ORIGIN_CONFIG_UPDATE"; config: Record<string, unknown> }
+  /** Pushed by the host whenever a subscribed event fires (e.g. pty:data). */
+  | { type: "ORIGIN_EVENT"; subscriptionId: string; payload: unknown };
 
 export type PluginToHostMessage =
   | { type: "ORIGIN_READY" }
@@ -17,12 +21,15 @@ export type PluginToHostMessage =
       id: string;
       command: string;
       args: Record<string, unknown>;
-    };
+    }
+  /** Sent by the plugin to persist a shallow config patch on the host. */
+  | { type: "ORIGIN_CONFIG_SET"; patch: Record<string, unknown> };
 
 export interface IframePluginContext {
   cardId: string;
   workspacePath: string;
   theme: "light" | "dark";
+  config: Record<string, unknown>;
 }
 
 /**

--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -67,6 +67,11 @@ type WorkspaceActions = {
   setSplitAutoLaunch: (v: boolean) => void;
   setZoomedNodeId: (id: string | null) => void;
   /**
+   * Shallow-merge a config patch into the leaf node's config.
+   * No-op if the node does not exist or is not a leaf.
+   */
+  setPluginConfig: (cardId: CardId, patch: Record<string, unknown>) => void;
+  /**
    * Ensure every loaded workspace has a bus instance.
    * Call once after tauriHandler.start() resolves to reconstruct buses
    * for workspaces that were deserialized from disk (functions are not persisted).
@@ -558,6 +563,15 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
       setZoomedNodeId: (id) =>
         set((draft) => {
           draft.zoomedNodeId = id;
+        }),
+
+      setPluginConfig: (cardId, patch) =>
+        set((draft) => {
+          const ws = getActiveWs(draft);
+          if (!ws) return;
+          const node = ws.nodes[cardId];
+          if (!node || node.type !== "leaf") return;
+          node.config = { ...node.config, ...patch };
         }),
 
       hydrateBuses: () =>

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -5,6 +5,8 @@ export type CardLeaf = {
   id: CardId;
   parentId: CardId | null;
   pluginId: string | null;
+  /** Per-instance plugin configuration. Shallow-merged by setPluginConfig. */
+  config?: Record<string, unknown>;
 };
 
 export type CardSplit = {


### PR DESCRIPTION
## Summary

- Adds `config?: Record<string, unknown>` to `CardLeaf` — persisted automatically via the existing `workspaces` key in the Tauri store
- Adds `PluginContext.config` and `PluginContext.setConfig(patch)` to `@origin/api` so every plugin can read and write per-instance config without touching the filesystem
- Wires the new fields through `Card.tsx`, `PluginHost.tsx`, and `IframePluginHost.tsx` (L1 iframe plugins receive config via `ORIGIN_INIT` and can call `setConfig` via the new `ORIGIN_CONFIG_SET` postMessage type)
- Adds `IframePluginContextWithConfig` to `@origin/sdk`; `usePluginContext()` now returns `setConfig` and handles `ORIGIN_CONFIG_UPDATE` messages for live config sync
- Migrates `@origin/github` to use `context.config`/`context.setConfig` instead of `readTextFile`/`writeTextFile` for owner/repo persistence — simplifies the plugin and removes the Tauri FS dependency

## Test plan

- [ ] Open GitHub plugin in a new panel — setup screen appears (no config yet)
- [ ] Enter an owner/repo and click Connect — PRs load, config is saved
- [ ] Close and reopen app — GitHub plugin restores owner/repo from persisted config
- [ ] Split a panel and open GitHub plugin in both sides — each instance has independent config
- [ ] Verify `CardLeaf.config` appears in the persisted workspace JSON file

## Notes

All pre-existing typecheck errors (App.tsx, PluginHost.tsx, workspaceStore.ts `filterKeysStrategy`) were present before this PR. This PR introduces zero new type errors.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/163?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->