### PR TITLE
feat: ORIGIN_EVENT — host-push streaming for L1 plugins (#145)

### DIFF
--- a/src/lib/iframeProtocol.ts
+++ b/src/lib/iframeProtocol.ts
@@ -23,7 +23,14 @@ export type PluginToHostMessage =
       args: Record<string, unknown>;
     }
   /** Sent by the plugin to persist a shallow config patch on the host. */
-  | { type: "ORIGIN_CONFIG_SET"; patch: Record<string, unknown> };
+  | { type: "ORIGIN_CONFIG_SET"; patch: Record<string, unknown> }
+  | {
+      type: "ORIGIN_EVENT_SUBSCRIBE";
+      subscriptionId: string;
+      event: string;
+      args?: Record<string, unknown>;
+    }
+  | { type: "ORIGIN_EVENT_UNSUBSCRIBE"; subscriptionId: string };
 
 export interface IframePluginContext {
   cardId: string;
@@ -57,4 +64,14 @@ export const COMMAND_CAPABILITY_MAP: Record<string, string> = {
   pty_write: "pty",
   pty_resize: "pty",
   pty_destroy: "pty",
+};
+
+/**
+ * Maps event names to the required capability string a plugin must declare in
+ * its manifest.requiredCapabilities to subscribe to that event.
+ *
+ * Events not present here are unconditionally denied.
+ */
+export const EVENT_CAPABILITY_MAP: Record<string, string> = {
+  "pty:data": "pty",
 };

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -21,8 +21,8 @@ export interface RegistryEntry {
   load: () => Promise<PluginModule>;
   /**
    * Full manifest for L1 (sandboxed iframe) plugins — used by IframePluginHost
-   * to enforce the capability allow-list for ORIGIN_INVOKE. Absent for L0
-   * plugins (they run in the main React tree and call Tauri directly).
+   * to enforce the capability allow-list for ORIGIN_INVOKE and ORIGIN_EVENT_SUBSCRIBE.
+   * Absent for L0 plugins (they run in the main React tree and call Tauri directly).
    */
   manifest?: PluginManifest;
 }


### PR DESCRIPTION
## Summary

- Adds `ORIGIN_EVENT_SUBSCRIBE` / `ORIGIN_EVENT_UNSUBSCRIBE` to `PluginToHostMessage` and `ORIGIN_EVENT` to `HostToPluginMessage` in `iframeProtocol.ts`
- Adds `EVENT_CAPABILITY_MAP` — a deny-by-default registry mapping event names to required capabilities (`"pty:data"` → `"pty"`)
- `IframePluginHost` handles subscriptions with the same two-gate security check as ORIGIN_INVOKE: event must be in `EVENT_CAPABILITY_MAP` and the plugin's manifest must declare the required capability
- For `"pty:data"`: creates a Tauri `Channel<number[]>`, wires `channel.onmessage` to forward bytes as `{ type: "ORIGIN_EVENT", subscriptionId, payload: { data } }`, invokes `pty_spawn`; stores `pty_destroy` as the cleanup function
- On unsubscribe or iframe unmount: all cleanup functions are called (destroys open PTY sessions)
- Also includes the ORIGIN_INVOKE additions from #144 (not yet merged): `COMMAND_CAPABILITY_MAP`, `manifest` prop on `IframePluginHost`, `RegistryEntry.manifest`, `initRegistry()` population, and `ORIGIN_INVOKE`/`ORIGIN_INVOKE_RESULT`/`ORIGIN_INVOKE_ERROR` protocol types

## Test plan

- [ ] TypeScript: `npm run typecheck` passes with no new errors in touched files
- [ ] `iframeProtocol.ts`: `ORIGIN_EVENT`, `ORIGIN_EVENT_SUBSCRIBE`, `ORIGIN_EVENT_UNSUBSCRIBE`, `EVENT_CAPABILITY_MAP` all exported correctly
- [ ] `IframePluginHost`: `eventUnsubs` map initialised; subscribe/unsubscribe/unmount all clean up PTY sessions
- [ ] Security gate: plugin without `"pty"` in `requiredCapabilities` cannot subscribe to `"pty:data"` (silently dropped, no crash)
- [ ] Security gate: unknown event name is silently dropped
- [ ] Double-subscribe guard: sending `ORIGIN_EVENT_SUBSCRIBE` twice with the same `subscriptionId` only spawns one PTY

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/165?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->