### PR TITLE
feat: GitHub plugin — configurable repo, issues tab, first-run setup (#143)

### DIFF
--- a/packages/github/src/index.tsx
+++ b/packages/github/src/index.tsx
@@ -4,15 +4,42 @@ import { useState, useEffect, useCallback } from "react";
 import type { PluginContext } from "@origin/api";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface GithubUser {
+  login: string;
+  avatar_url: string;
+}
+
+interface GithubLabel {
+  name: string;
+  color: string;
+}
+
 interface PR {
   number: number;
   title: string;
-  user: { login: string; avatar_url: string };
+  user: GithubUser;
   html_url: string;
   draft: boolean;
   created_at: string;
-  labels: { name: string; color: string }[];
+  labels: GithubLabel[];
 }
+
+interface Issue {
+  number: number;
+  title: string;
+  user: GithubUser;
+  html_url: string;
+  created_at: string;
+  labels: GithubLabel[];
+  /** Present when the item is a PR — used to filter them out of the issues list. */
+  pull_request?: unknown;
+}
+
+type Tab = "prs" | "issues";
+
+// ─── Utilities ───────────────────────────────────────────────────────────────
 
 function relativeTime(isoDate: string): string {
   const diff = Date.now() - new Date(isoDate).getTime();
@@ -23,54 +50,210 @@ function relativeTime(isoDate: string): string {
   return `${Math.floor(hours / 24)}d ago`;
 }
 
-export default function GitHubPlugin({ context }: { context: PluginContext }) {
+function apiErrorMessage(status: number): string {
+  if (status === 404)
+    return "Repo not found or private. GitHub API requires the repo to be public.";
+  if (status === 403)
+    return "GitHub API rate limit reached. Try again in a few minutes.";
+  return `GitHub API error (HTTP ${status})`;
+}
+
+// ─── Label chip ──────────────────────────────────────────────────────────────
+
+interface LabelChipProps {
+  label: GithubLabel;
+}
+
+function LabelChip({ label }: LabelChipProps): JSX.Element {
+  return (
+    <span
+      className="rounded-full px-1.5 py-px text-xs"
+      style={{
+        backgroundColor: `#${label.color}33`,
+        color: `#${label.color}`,
+      }}
+    >
+      {label.name}
+    </span>
+  );
+}
+
+// ─── PR row ──────────────────────────────────────────────────────────────────
+
+interface PRRowProps {
+  pr: PR;
+  isDark: boolean;
+}
+
+function PRRow({ pr, isDark }: PRRowProps): JSX.Element {
+  return (
+    <button
+      className={`w-full border-b px-3 py-2.5 text-left transition-colors ${
+        isDark
+          ? "border-zinc-700/50 hover:bg-zinc-800"
+          : "border-zinc-100 hover:bg-zinc-50"
+      }`}
+      onClick={() => openUrl(pr.html_url)}
+    >
+      <div className="flex items-start gap-2">
+        <span className="mt-0.5 text-xs leading-5">
+          {pr.draft ? "⚫" : "🟢"}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline gap-1.5">
+            <span className="shrink-0 text-xs opacity-40">#{pr.number}</span>
+            <span className="truncate text-sm leading-5">{pr.title}</span>
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1">
+            <img
+              src={pr.user.avatar_url}
+              alt={pr.user.login}
+              className="h-4 w-4 rounded-full"
+            />
+            <span className="text-xs opacity-50">{pr.user.login}</span>
+            <span className="text-xs opacity-30">·</span>
+            <span className="text-xs opacity-50">
+              {relativeTime(pr.created_at)}
+            </span>
+            {pr.labels.map((label) => (
+              <LabelChip key={label.name} label={label} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+// ─── Issue row ───────────────────────────────────────────────────────────────
+
+interface IssueRowProps {
+  issue: Issue;
+  isDark: boolean;
+}
+
+function IssueRow({ issue, isDark }: IssueRowProps): JSX.Element {
+  return (
+    <button
+      className={`w-full border-b px-3 py-2.5 text-left transition-colors ${
+        isDark
+          ? "border-zinc-700/50 hover:bg-zinc-800"
+          : "border-zinc-100 hover:bg-zinc-50"
+      }`}
+      onClick={() => openUrl(issue.html_url)}
+    >
+      <div className="flex items-start gap-2">
+        <span className="mt-0.5 text-xs leading-5 text-green-500">●</span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline gap-1.5">
+            <span className="shrink-0 text-xs opacity-40">
+              #{issue.number}
+            </span>
+            <span className="truncate text-sm leading-5">{issue.title}</span>
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1">
+            <img
+              src={issue.user.avatar_url}
+              alt={issue.user.login}
+              className="h-4 w-4 rounded-full"
+            />
+            <span className="text-xs opacity-50">{issue.user.login}</span>
+            <span className="text-xs opacity-30">·</span>
+            <span className="text-xs opacity-50">
+              {relativeTime(issue.created_at)}
+            </span>
+            {issue.labels.map((label) => (
+              <LabelChip key={label.name} label={label} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+// ─── Main component ──────────────────────────────────────────────────────────
+
+export default function GitHubPlugin({
+  context,
+}: {
+  context: PluginContext;
+}): JSX.Element {
   // Derive owner/repo from persisted config (context.config is shallow-merged)
   const savedOwner = (context.config.owner as string | undefined) ?? "";
   const savedRepo = (context.config.repo as string | undefined) ?? "";
 
-  const [owner, setOwner] = useState(savedOwner);
-  const [repo, setRepo] = useState(savedRepo);
+  const [ownerInput, setOwnerInput] = useState(savedOwner);
+  const [repoInput, setRepoInput] = useState(savedRepo);
   const [configured, setConfigured] = useState(
     Boolean(savedOwner && savedRepo),
   );
   const [showSettings, setShowSettings] = useState(false);
+
+  const [activeTab, setActiveTab] = useState<Tab>("prs");
   const [prs, setPrs] = useState<PR[]>([]);
+  const [issues, setIssues] = useState<Issue[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lastFetched, setLastFetched] = useState<number | null>(null);
+
   const isDark = context.theme === "dark";
 
-  // Sync local state when config changes externally (e.g. another panel)
+  // Sync local input state when config changes externally (e.g. same card in
+  // another workspace tab, or a future "duplicate panel" action).
   useEffect(() => {
     const o = (context.config.owner as string | undefined) ?? "";
     const r = (context.config.repo as string | undefined) ?? "";
-    setOwner(o);
-    setRepo(r);
+    setOwnerInput(o);
+    setRepoInput(r);
     setConfigured(Boolean(o && r));
   }, [context.config.owner, context.config.repo]);
 
+  // ── Fetch helpers ─────────────────────────────────────────────────────────
+
   const fetchPRs = useCallback(async (o: string, r: string) => {
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetch(
-        `https://api.github.com/repos/${o}/${r}/pulls?state=open&per_page=20`,
-      );
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data: PR[] = (await res.json()) as PR[];
-      setPrs(data);
-      setLastFetched(Date.now());
-    } catch {
-      setError("Could not load PRs — check repo name");
-    } finally {
-      setLoading(false);
-    }
+    const res = await fetch(
+      `https://api.github.com/repos/${o}/${r}/pulls?state=open&per_page=30`,
+    );
+    if (!res.ok) throw new Error(apiErrorMessage(res.status));
+    const data = (await res.json()) as PR[];
+    setPrs(data);
   }, []);
+
+  const fetchIssues = useCallback(async (o: string, r: string) => {
+    const res = await fetch(
+      `https://api.github.com/repos/${o}/${r}/issues?state=open&per_page=30`,
+    );
+    if (!res.ok) throw new Error(apiErrorMessage(res.status));
+    const data = (await res.json()) as Issue[];
+    // GitHub's issues endpoint includes PRs — filter them out
+    setIssues(data.filter((item) => !item.pull_request));
+  }, []);
+
+  const fetchAll = useCallback(
+    async (o: string, r: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        await Promise.all([fetchPRs(o, r), fetchIssues(o, r)]);
+        setLastFetched(Date.now());
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Could not load data from GitHub",
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [fetchPRs, fetchIssues],
+  );
 
   // Fetch on initial load if already configured
   useEffect(() => {
     if (savedOwner && savedRepo) {
-      void fetchPRs(savedOwner, savedRepo);
+      void fetchAll(savedOwner, savedRepo);
     }
     // Only run once on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -79,22 +262,47 @@ export default function GitHubPlugin({ context }: { context: PluginContext }) {
   // Auto-refresh every 5 minutes
   useEffect(() => {
     if (!configured || showSettings) return;
-    const id = setInterval(() => fetchPRs(owner, repo), 5 * 60 * 1000);
+    const o = (context.config.owner as string | undefined) ?? "";
+    const r = (context.config.repo as string | undefined) ?? "";
+    if (!o || !r) return;
+    const id = setInterval(() => void fetchAll(o, r), 5 * 60 * 1000);
     return () => clearInterval(id);
-  }, [configured, showSettings, owner, repo, fetchPRs]);
+  }, [
+    configured,
+    showSettings,
+    context.config.owner,
+    context.config.repo,
+    fetchAll,
+  ]);
+
+  // ── Handlers ──────────────────────────────────────────────────────────────
 
   const handleConnect = useCallback(() => {
-    const o = owner.trim();
-    const r = repo.trim();
+    const o = ownerInput.trim();
+    const r = repoInput.trim();
     if (!o || !r) return;
-    // Persist to workspace store — replaces file-based config
+    // Persist to workspace store via context — shallow-merged into card config
     context.setConfig({ owner: o, repo: r });
-    setOwner(o);
-    setRepo(r);
     setConfigured(true);
     setShowSettings(false);
-    void fetchPRs(o, r);
-  }, [owner, repo, fetchPRs, context]);
+    void fetchAll(o, r);
+  }, [ownerInput, repoInput, fetchAll, context]);
+
+  const handleDisconnect = useCallback(() => {
+    context.setConfig({ owner: "", repo: "" });
+    setOwnerInput("");
+    setRepoInput("");
+    setConfigured(false);
+    setPrs([]);
+    setIssues([]);
+    setError(null);
+    setLastFetched(null);
+  }, [context]);
+
+  // ── Derived ───────────────────────────────────────────────────────────────
+
+  const owner = (context.config.owner as string | undefined) ?? "";
+  const repo = (context.config.repo as string | undefined) ?? "";
 
   const minutesAgo =
     lastFetched !== null
@@ -107,73 +315,90 @@ export default function GitHubPlugin({ context }: { context: PluginContext }) {
       : "border-zinc-300 bg-white text-zinc-900 placeholder:text-zinc-400 focus:ring-zinc-400"
   }`;
 
-  // Setup / settings screen
+  const borderClass = isDark ? "border-zinc-700" : "border-zinc-200";
+
+  // ── Setup / settings screen ───────────────────────────────────────────────
+
   if (!configured || showSettings) {
     return (
       <div
-        className={`flex h-full flex-col items-center justify-center gap-4 p-6 ${
-          isDark ? "text-zinc-100" : "text-zinc-900"
-        }`}
+        className={`flex h-full flex-col ${isDark ? "text-zinc-100" : "text-zinc-900"}`}
       >
-        <div className="text-3xl">🐙</div>
-        <h2 className="text-sm font-semibold">Connect a repository</h2>
-        <div className="flex w-full max-w-xs flex-col gap-2">
-          <input
-            className={inputClass}
-            placeholder="Owner"
-            value={owner}
-            onChange={(e) => setOwner(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && handleConnect()}
-          />
-          <input
-            className={inputClass}
-            placeholder="Repository"
-            value={repo}
-            onChange={(e) => setRepo(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && handleConnect()}
-          />
-          <button
-            className={`rounded py-2 text-sm font-medium transition-colors disabled:opacity-50 ${
-              isDark
-                ? "bg-zinc-700 text-zinc-100 hover:bg-zinc-600"
-                : "bg-zinc-900 text-white hover:bg-zinc-700"
-            }`}
-            onClick={handleConnect}
-            disabled={loading}
+        {/* Settings sub-header when reconfiguring an already-configured repo */}
+        {configured && showSettings && (
+          <div
+            className={`flex items-center gap-2 border-b px-3 py-2 ${borderClass}`}
           >
-            {loading ? "Connecting…" : "Connect"}
-          </button>
-          {error && <p className="text-xs text-red-400">{error}</p>}
-          {configured && (
+            <span className="flex-1 text-sm font-medium">Settings</span>
             <button
               className="text-xs opacity-50 hover:opacity-100"
               onClick={() => setShowSettings(false)}
             >
               Cancel
             </button>
-          )}
+          </div>
+        )}
+
+        <div className="flex flex-1 flex-col items-center justify-center gap-4 p-6">
+          <div className="text-3xl">🐙</div>
+          <h2 className="text-sm font-semibold">Connect a repository</h2>
+          <div className="flex w-full max-w-xs flex-col gap-2">
+            <input
+              className={inputClass}
+              placeholder="Owner"
+              value={ownerInput}
+              onChange={(e) => setOwnerInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleConnect()}
+            />
+            <input
+              className={inputClass}
+              placeholder="Repository"
+              value={repoInput}
+              onChange={(e) => setRepoInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleConnect()}
+            />
+            <button
+              className={`rounded py-2 text-sm font-medium transition-colors disabled:opacity-50 ${
+                isDark
+                  ? "bg-zinc-700 text-zinc-100 hover:bg-zinc-600"
+                  : "bg-zinc-900 text-white hover:bg-zinc-700"
+              }`}
+              onClick={handleConnect}
+              disabled={loading || !ownerInput.trim() || !repoInput.trim()}
+            >
+              {loading ? "Connecting…" : "Connect"}
+            </button>
+            {error && <p className="text-xs text-red-400">{error}</p>}
+            {configured && (
+              <button
+                className="mt-1 text-xs text-red-400 opacity-70 hover:opacity-100"
+                onClick={handleDisconnect}
+              >
+                Disconnect
+              </button>
+            )}
+          </div>
         </div>
       </div>
     );
   }
 
-  // PR list view
+  // ── Main view (tabbed: PRs | Issues) ─────────────────────────────────────
+
   return (
     <div
       className={`flex h-full flex-col ${isDark ? "text-zinc-100" : "text-zinc-900"}`}
     >
       {/* Header */}
       <div
-        className={`flex items-center gap-2 border-b px-3 py-2 ${
-          isDark ? "border-zinc-700" : "border-zinc-200"
-        }`}
+        className={`flex items-center gap-2 border-b px-3 py-2 ${borderClass}`}
       >
         <span className="flex-1 truncate text-sm font-medium">
           {owner}/{repo}
         </span>
         <button
           className="text-sm opacity-50 hover:opacity-100"
-          onClick={() => fetchPRs(owner, repo)}
+          onClick={() => void fetchAll(owner, repo)}
           title="Refresh"
         >
           ↻
@@ -185,6 +410,25 @@ export default function GitHubPlugin({ context }: { context: PluginContext }) {
         >
           ⚙
         </button>
+      </div>
+
+      {/* Tab bar */}
+      <div className={`flex border-b ${borderClass}`}>
+        {(["prs", "issues"] as Tab[]).map((tab) => (
+          <button
+            key={tab}
+            className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+              activeTab === tab
+                ? isDark
+                  ? "border-b-2 border-zinc-300 text-zinc-100"
+                  : "border-b-2 border-zinc-900 text-zinc-900"
+                : "opacity-50 hover:opacity-80"
+            }`}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab === "prs" ? "Pull Requests" : "Issues"}
+          </button>
+        ))}
       </div>
 
       {/* Last fetched */}
@@ -201,67 +445,38 @@ export default function GitHubPlugin({ context }: { context: PluginContext }) {
             Loading…
           </div>
         )}
+
         {!loading && error && (
           <div className="px-3 py-4 text-sm text-red-400">{error}</div>
         )}
-        {!loading && !error && prs.length === 0 && (
-          <div className="flex h-full items-center justify-center text-sm opacity-50">
-            No open pull requests 🎉
-          </div>
-        )}
-        {!loading &&
-          !error &&
-          prs.map((pr) => (
-            <button
-              key={pr.number}
-              className={`w-full border-b px-3 py-2.5 text-left transition-colors ${
-                isDark
-                  ? "border-zinc-700/50 hover:bg-zinc-800"
-                  : "border-zinc-100 hover:bg-zinc-50"
-              }`}
-              onClick={() => openUrl(pr.html_url)}
-            >
-              <div className="flex items-start gap-2">
-                <span className="mt-0.5 text-xs leading-5">
-                  {pr.draft ? "⚫" : "🟢"}
-                </span>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-baseline gap-1.5">
-                    <span className="shrink-0 text-xs opacity-40">
-                      #{pr.number}
-                    </span>
-                    <span className="truncate text-sm leading-5">
-                      {pr.title}
-                    </span>
-                  </div>
-                  <div className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1">
-                    <img
-                      src={pr.user.avatar_url}
-                      alt={pr.user.login}
-                      className="h-4 w-4 rounded-full"
-                    />
-                    <span className="text-xs opacity-50">{pr.user.login}</span>
-                    <span className="text-xs opacity-30">·</span>
-                    <span className="text-xs opacity-50">
-                      {relativeTime(pr.created_at)}
-                    </span>
-                    {pr.labels.map((label) => (
-                      <span
-                        key={label.name}
-                        className="rounded-full px-1.5 py-px text-xs"
-                        style={{
-                          backgroundColor: `#${label.color}33`,
-                          color: `#${label.color}`,
-                        }}
-                      >
-                        {label.name}
-                      </span>
-                    ))}
-                  </div>
-                </div>
+
+        {!loading && !error && activeTab === "prs" && (
+          <>
+            {prs.length === 0 ? (
+              <div className="flex h-full items-center justify-center text-sm opacity-50">
+                No open pull requests
               </div>
-            </button>
-          ))}
+            ) : (
+              prs.map((pr) => (
+                <PRRow key={pr.number} pr={pr} isDark={isDark} />
+              ))
+            )}
+          </>
+        )}
+
+        {!loading && !error && activeTab === "issues" && (
+          <>
+            {issues.length === 0 ? (
+              <div className="flex h-full items-center justify-center text-sm opacity-50">
+                No open issues
+              </div>
+            ) : (
+              issues.map((issue) => (
+                <IssueRow key={issue.number} issue={issue} isDark={isDark} />
+              ))
+            )}
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **Issues tab**: New "Pull Requests | Issues" tab bar fetches from the GitHub issues API, filters out PRs (items with a `pull_request` key), and displays each issue with number, title, author avatar (16px), labels (coloured chips), and relative timestamp
- **Error handling**: API 404 → "Repo not found or private. GitHub API requires the repo to be public." and 403 → "GitHub API rate limit reached. Try again in a few minutes." instead of the generic fallback
- **Disconnect button**: Settings form now includes a "Disconnect" button that clears `context.config` (`{ owner: "", repo: "" }`) and returns to the first-run setup screen
- **Code structure**: Extracted `LabelChip`, `PRRow`, and `IssueRow` as typed sub-components; `fetchAll()` runs PR + Issues fetches in parallel with `Promise.all`; local `ownerInput`/`repoInput` state is separated from `context.config`-derived `owner`/`repo` to avoid stale closure issues

## Test plan

- [ ] First-run: Open a new GitHub panel — confirm the setup form is shown
- [ ] Connect: Enter owner + repo, press Connect — confirm PRs list loads and the "Pull Requests" tab is active
- [ ] Issues tab: Click "Issues" — confirm issues load (without PR items in the list)
- [ ] Tab switching: Switch between PRs and Issues — confirm content updates correctly
- [ ] Settings: Click ⚙ — confirm the settings form shows with "Cancel" and "Disconnect" buttons
- [ ] Disconnect: Click "Disconnect" — confirm config clears and first-run form appears
- [ ] Error - 404: Enter a private/nonexistent repo — confirm "Repo not found or private" message
- [ ] Error - 403: Exhaust rate limit — confirm "GitHub API rate limit reached" message
- [ ] Persistence: Reload the app — confirm owner/repo is restored from `context.config` and PRs/issues load automatically
- [ ] Dark mode: Confirm all UI elements render correctly in dark mode

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/166?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->