### PR TITLE
feat(api): invoke() and onEvent() on PluginContext (#146)

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -6,6 +6,32 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.7.0] — 2026-02-25
+
+Issue: #146
+
+### Added
+
+- `PluginContext.invoke<T>(command, args?)` — proxy a Tauri command through the
+  shell. Implemented in `@origin/sdk` via the `ORIGIN_INVOKE` / `ORIGIN_INVOKE_RESULT`
+  / `ORIGIN_INVOKE_ERROR` postMessage protocol. The plugin must declare the
+  required capability in `PluginManifest.requiredCapabilities`; the shell rejects
+  calls for undeclared capabilities.
+- `PluginContext.onEvent(event, args, handler)` — subscribe to a named
+  host-push event stream (e.g. `"pty:data"`). Implemented in `@origin/sdk` via
+  the `ORIGIN_EVENT_SUBSCRIBE` / `ORIGIN_EVENT` / `ORIGIN_EVENT_UNSUBSCRIBE`
+  postMessage protocol. Returns an unsubscribe function.
+- `@origin/sdk`: `invoke<T>(command, args?)` — standalone function wrapping the
+  ORIGIN_INVOKE protocol. Uses `crypto.randomUUID()` for correlation IDs.
+  Cleans up the message listener on resolve/reject.
+- `@origin/sdk`: `onEvent(event, args, handler)` — standalone function wrapping
+  the ORIGIN_EVENT_SUBSCRIBE protocol. Returns a cleanup function that sends
+  ORIGIN_EVENT_UNSUBSCRIBE.
+- `@origin/sdk`: `useOriginEvent(event, args, handler)` — React hook wrapping
+  `onEvent` with `useEffect` cleanup for React plugin components.
+
+---
+
 ## [0.6.0] — 2026-02-24
 
 Issue: #141
@@ -138,6 +164,7 @@ a standalone `@origin-cards/api` workspace package.
 
 ---
 
+[0.7.0]: https://github.com/fellanH/origin/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/fellanH/origin/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/fellanH/origin/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/fellanH/origin/compare/v0.3.0...v0.4.0

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -106,6 +106,30 @@ export interface PluginContext {
    * useEffect(() => context.on('focus', () => console.log('focused')), []);
    */
   on(event: PluginLifecycleEvent, handler: () => void): () => void;
+  /**
+   * Proxy a Tauri command through the shell.
+   * The plugin must declare the required capability in its manifest
+   * (`requiredCapabilities`) — the shell will reject the call otherwise.
+   *
+   * @example
+   * const result = await context.invoke<string>("plugin:fs|read_text_file", { path: "/etc/hosts" });
+   */
+  invoke<T = unknown>(
+    command: string,
+    args?: Record<string, unknown>,
+  ): Promise<T>;
+  /**
+   * Subscribe to a named host-push event stream (e.g. `"pty:data"`).
+   * Returns an unsubscribe function — call it in your plugin's cleanup.
+   *
+   * @example
+   * useEffect(() => context.onEvent("pty:data", { sessionId }, ({ data }) => xterm.write(data)), []);
+   */
+  onEvent(
+    event: string,
+    args: Record<string, unknown>,
+    handler: (payload: unknown) => void,
+  ): () => void;
 }
 
 export type PluginComponent = React.ComponentType<{ context: PluginContext }>;

--- a/packages/sdk/src/events.ts
+++ b/packages/sdk/src/events.ts
@@ -1,0 +1,79 @@
+import { useEffect } from "react";
+import type { HostToPluginMessage } from "@/lib/iframeProtocol";
+
+/**
+ * Subscribe to a named host-push event stream (e.g. `"pty:data"`).
+ *
+ * Sends an `ORIGIN_EVENT_SUBSCRIBE` postMessage to the host and invokes
+ * `handler` each time the host pushes a matching `ORIGIN_EVENT`. Returns a
+ * cleanup function that sends `ORIGIN_EVENT_UNSUBSCRIBE` to the host.
+ *
+ * @param event   - Event name as registered on the host, e.g. `"pty:data"`.
+ * @param args    - Optional named arguments forwarded to the subscription.
+ * @param handler - Called with the event payload each time the event fires.
+ * @returns       An unsubscribe function — call it in your cleanup.
+ *
+ * @example
+ * const unsub = onEvent("pty:data", { sessionId }, ({ data }) => xterm.write(data));
+ * // later:
+ * unsub();
+ */
+export function onEvent(
+  event: string,
+  args: Record<string, unknown> | undefined,
+  handler: (payload: unknown) => void,
+): () => void {
+  const subscriptionId = crypto.randomUUID();
+
+  function onMessage(ev: MessageEvent) {
+    const msg = ev.data as HostToPluginMessage;
+    if (msg.type === "ORIGIN_EVENT" && msg.subscriptionId === subscriptionId) {
+      handler(msg.payload);
+    }
+  }
+
+  window.addEventListener("message", onMessage);
+
+  window.parent.postMessage(
+    { type: "ORIGIN_EVENT_SUBSCRIBE", subscriptionId, event, args },
+    "*",
+  );
+
+  return () => {
+    window.removeEventListener("message", onMessage);
+    window.parent.postMessage(
+      { type: "ORIGIN_EVENT_UNSUBSCRIBE", subscriptionId },
+      "*",
+    );
+  };
+}
+
+/**
+ * React hook that subscribes to a host-push event stream and cleans up on
+ * unmount or when any argument changes.
+ *
+ * Wraps {@link onEvent} with a `useEffect` so subscriptions are automatically
+ * torn down when the component unmounts or dependencies change.
+ *
+ * @param event   - Event name as registered on the host, e.g. `"pty:data"`.
+ * @param args    - Named arguments forwarded to the subscription. Must be
+ *                  stable across renders (wrap with `useMemo` or keep outside
+ *                  the component) to avoid infinite re-subscription loops.
+ * @param handler - Called with the event payload each time the event fires.
+ *                  Must be stable (wrap with `useCallback`) to avoid loops.
+ *
+ * @example
+ * useOriginEvent("pty:data", { sessionId }, useCallback(({ data }) => {
+ *   xterm.write(new Uint8Array(data as number[]));
+ * }, [xterm]));
+ */
+export function useOriginEvent(
+  event: string,
+  args: Record<string, unknown> | undefined,
+  handler: (payload: unknown) => void,
+): void {
+  useEffect(() => {
+    return onEvent(event, args, handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [event, JSON.stringify(args), handler]);
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,6 @@
 export { usePluginContext } from "./context";
 export type { IframePluginContextWithConfig } from "./context";
 export { useBusChannel } from "./bus";
+export { invoke } from "./invoke";
+export { onEvent, useOriginEvent } from "./events";
 export type { IframePluginContext } from "@/lib/iframeProtocol";

--- a/packages/sdk/src/invoke.ts
+++ b/packages/sdk/src/invoke.ts
@@ -1,0 +1,46 @@
+import type { HostToPluginMessage } from "@/lib/iframeProtocol";
+
+/**
+ * Proxy a Tauri command through the shell via the ORIGIN_INVOKE protocol.
+ *
+ * Sends an `ORIGIN_INVOKE` postMessage to the host and waits for the matching
+ * `ORIGIN_INVOKE_RESULT` or `ORIGIN_INVOKE_ERROR` response. Uses a UUID
+ * correlation ID internally.
+ *
+ * The plugin must declare the required capability in its manifest
+ * (`requiredCapabilities`) — the shell will reject the call otherwise.
+ *
+ * @param command - Tauri command name, e.g. `"plugin:fs|read_text_file"`.
+ * @param args    - Optional named arguments forwarded to the command.
+ * @returns       A Promise that resolves with the command result or rejects
+ *                with the error message sent by the host.
+ *
+ * @example
+ * const text = await invoke<string>("plugin:fs|read_text_file", { path: "/etc/hosts" });
+ */
+export function invoke<T = unknown>(
+  command: string,
+  args?: Record<string, unknown>,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const id = crypto.randomUUID();
+
+    function onMessage(event: MessageEvent) {
+      const msg = event.data as HostToPluginMessage;
+      if (msg.type === "ORIGIN_INVOKE_RESULT" && msg.id === id) {
+        window.removeEventListener("message", onMessage);
+        resolve(msg.result as T);
+      } else if (msg.type === "ORIGIN_INVOKE_ERROR" && msg.id === id) {
+        window.removeEventListener("message", onMessage);
+        reject(new Error(msg.error));
+      }
+    }
+
+    window.addEventListener("message", onMessage);
+
+    window.parent.postMessage(
+      { type: "ORIGIN_INVOKE", id, command, args: args ?? {} },
+      "*",
+    );
+  });
+}


### PR DESCRIPTION
Closes #146

Adds `invoke()` and `onEvent()` to `PluginContext` so L1 plugins can call Tauri commands and subscribe to streaming events without touching postMessage directly.

## Summary

- `PluginContext.invoke<T>(command, args?)` — type-level contract in `@origin/api`. For L1 plugins the shell proxies the call via the `ORIGIN_INVOKE` / `ORIGIN_INVOKE_RESULT` / `ORIGIN_INVOKE_ERROR` postMessage protocol (already implemented in `IframePluginHost`). For L0 plugins `Card.tsx` wires this directly to Tauri's `invoke()`.
- `PluginContext.onEvent(event, args, handler)` — type-level contract in `@origin/api`. For L1 plugins the shell uses the `ORIGIN_EVENT_SUBSCRIBE` / `ORIGIN_EVENT` / `ORIGIN_EVENT_UNSUBSCRIBE` protocol. For L0 plugins a no-op stub is provided (L0 plugins have direct Tauri access).
- `@origin/sdk` `invoke<T>()` — standalone function in `packages/sdk/src/invoke.ts`. Sends `ORIGIN_INVOKE`, awaits the matching response by UUID correlation ID, resolves or rejects the Promise, and removes the listener on completion.
- `@origin/sdk` `onEvent()` — standalone function in `packages/sdk/src/events.ts`. Sends `ORIGIN_EVENT_SUBSCRIBE`, calls handler on each `ORIGIN_EVENT` matching the `subscriptionId`, returns a cleanup function that sends `ORIGIN_EVENT_UNSUBSCRIBE`.
- `@origin/sdk` `useOriginEvent()` — React hook wrapping `onEvent` with `useEffect` cleanup.
- All three new SDK exports added to `packages/sdk/src/index.ts`.
- `packages/api/CHANGELOG.md` updated with `[0.7.0]` entry.

## Test plan

- [ ] `npm run typecheck` passes (pre-existing errors in `src/` are unrelated to this PR)
- [ ] L1 plugin can call `invoke("plugin:fs|read_text_file", { path })` and receive the result
- [ ] L1 plugin calling an undeclared capability receives a rejection from the shell
- [ ] L1 plugin subscribing to `"pty:data"` via `onEvent` receives payloads; calling the returned unsubscribe function stops delivery
- [ ] `useOriginEvent` cleans up on unmount (no stale listeners after component teardown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/167?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->