### PR TITLE
feat: seed_bundled_plugins Rust command + bundle.resources config

### DIFF
--- a/src-tauri/assets/plugins/_placeholder/README
+++ b/src-tauri/assets/plugins/_placeholder/README
@@ -1,0 +1,1 @@
+This directory is populated by scripts/export-preinstalled.mjs from the origin-plugins monorepo.

--- a/src-tauri/src/commands/plugins.rs
+++ b/src-tauri/src/commands/plugins.rs
@@ -91,6 +91,102 @@ pub fn restart_app(app: AppHandle) {
 }
 
 #[tauri::command]
+pub async fn seed_bundled_plugins(app: tauri::AppHandle) -> Result<Vec<String>, String> {
+    // Resolve the resource dir — this is where Tauri bundles the plugin assets.
+    let resource_plugins_dir = app
+        .path()
+        .resource_dir()
+        .map_err(|e| format!("Failed to resolve resource dir: {e}"))?
+        .join("plugins");
+
+    // Graceful no-op in dev builds where assets aren't bundled yet.
+    if !resource_plugins_dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let dest_plugins_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to resolve app data dir: {e}"))?
+        .join("plugins");
+
+    // Ensure the destination plugins directory exists.
+    std::fs::create_dir_all(&dest_plugins_dir)
+        .map_err(|e| format!("Failed to create plugins dir: {e}"))?;
+
+    let entries = std::fs::read_dir(&resource_plugins_dir)
+        .map_err(|e| format!("Failed to read resource plugins dir: {e}"))?;
+
+    let mut seeded: Vec<String> = Vec::new();
+
+    for entry in entries.flatten() {
+        let src_dir = entry.path();
+        if !src_dir.is_dir() {
+            continue;
+        }
+
+        // Read and parse manifest.json from the bundled plugin directory.
+        let src_manifest_path = src_dir.join("manifest.json");
+        let src_manifest_str = match std::fs::read_to_string(&src_manifest_path) {
+            Ok(s) => s,
+            Err(_) => continue, // Skip dirs without a manifest.json
+        };
+
+        #[derive(serde::Deserialize)]
+        struct MinimalManifest {
+            id: String,
+            version: String,
+        }
+
+        let src_manifest: MinimalManifest = match serde_json::from_str(&src_manifest_str) {
+            Ok(m) => m,
+            Err(_) => continue, // Skip dirs with invalid manifest.json
+        };
+
+        let dest_dir = dest_plugins_dir.join(&src_manifest.id);
+
+        // If the plugin is already installed, compare versions and skip if up to date.
+        if dest_dir.exists() {
+            let dest_manifest_path = dest_dir.join("manifest.json");
+            if let Ok(dest_manifest_str) = std::fs::read_to_string(&dest_manifest_path) {
+                if let Ok(dest_manifest) =
+                    serde_json::from_str::<MinimalManifest>(&dest_manifest_str)
+                {
+                    // Simple lexicographic semver compare — acceptable for single-digit
+                    // minor/patch versions (e.g. "0.1.0" < "0.2.0").
+                    if dest_manifest.version >= src_manifest.version {
+                        continue; // Installed version is same or newer; skip.
+                    }
+                }
+            }
+        }
+
+        // Copy the entire plugin directory to the destination.
+        std::fs::create_dir_all(&dest_dir)
+            .map_err(|e| format!("Failed to create dir for {}: {e}", src_manifest.id))?;
+
+        let plugin_entries = std::fs::read_dir(&src_dir)
+            .map_err(|e| format!("Failed to read bundled plugin dir {}: {e}", src_manifest.id))?;
+
+        for plugin_entry in plugin_entries.flatten() {
+            let entry_path = plugin_entry.path();
+            if entry_path.is_file() {
+                if let Some(filename) = entry_path.file_name() {
+                    let dest_file = dest_dir.join(filename);
+                    std::fs::copy(&entry_path, &dest_file).map_err(|e| {
+                        format!("Failed to copy {:?} for {}: {e}", filename, src_manifest.id)
+                    })?;
+                }
+            }
+        }
+
+        seeded.push(src_manifest.id);
+    }
+
+    Ok(seeded)
+}
+
+#[tauri::command]
 pub fn save_plugin_bundle(
     app: AppHandle,
     id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,6 +49,7 @@ pub fn run() {
             commands::plugins::install_plugin,
             commands::plugins::restart_app,
             commands::plugins::save_plugin_bundle,
+            commands::plugins::seed_bundled_plugins,
             pty::pty_spawn,
             pty::pty_write,
             pty::pty_resize,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,6 +33,9 @@
     ]
   },
   "bundle": {
+    "resources": {
+      "assets/plugins/**/*": "plugins/"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,6 +24,13 @@ async function bootstrap() {
     );
   }
 
+  // Seed bundled plugin assets from the Tauri resource bundle into AppData on
+  // first launch (or when a newer version is bundled). Graceful no-op in dev
+  // builds where assets/plugins/ is empty or absent.
+  await invoke("seed_bundled_plugins").catch((e) => {
+    console.warn("[origin] seed_bundled_plugins failed:", e);
+  });
+
   // Load persisted state from (possibly just-recovered) file.
   await Promise.all([tauriHandler.start(), initRegistry()]);
 


### PR DESCRIPTION
Closes phase 5 of plugin monorepo migration.

## Summary

- Adds `seed_bundled_plugins` Tauri command that seeds bundled plugin assets to AppData on first launch (or when a newer version is bundled)
- Adds `bundle.resources` config (`"assets/plugins/**/*": "plugins/"`) pointing to `src-tauri/assets/plugins/` for Tauri release bundling
- Calls `seed_bundled_plugins` in `main.tsx` before `initRegistry()` — graceful `.catch()` means dev builds with no bundled assets start cleanly
- Creates `src-tauri/assets/plugins/_placeholder/README` as a glob-valid placeholder; real plugin dirs will be written by `scripts/export-preinstalled.mjs` from the origin-plugins monorepo

## Behavior

- On launch: reads each plugin subdir from `resource_dir()/plugins`, compares `manifest.json` version against any already-installed copy in AppData
- Lexicographic semver compare (acceptable for single-digit minor/patch, e.g. `"0.1.0"` vs `"0.2.0"`)
- If installed version >= bundled version: skip (idempotent)
- If missing or older: copies all files from the resource dir into `app_data_dir()/plugins/{id}/`
- Returns `Vec<String>` of seeded plugin IDs

## Compilation

`cargo check` passes cleanly. Pre-existing TypeScript errors in `App.tsx`, `PluginHost.tsx`, `SettingsPanel.tsx.bak`, and `workspaceStore.ts` are not introduced by this PR.

## Test plan

- [ ] `cargo check` passes (verified)
- [ ] Dev build (`npm run tauri dev`): `seed_bundled_plugins` logs no error (resource dir absent → graceful no-op)
- [ ] Release build: after `scripts/export-preinstalled.mjs` populates `assets/plugins/`, bundled plugins appear in AppData after first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/168?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->