### PR TITLE
fix(keyboard): let clipboard shortcuts pass through global handler (#176)

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -29,6 +29,16 @@ export function useKeyboardShortcuts({
     function handleKeyDown(e: KeyboardEvent): void {
       if (!e.metaKey) return;
 
+      // Standard clipboard shortcuts — never intercept these; let the browser handle them.
+      // CMD+C (copy), CMD+V (paste), CMD+X (cut), CMD+A (select all)
+      if (
+        !e.altKey &&
+        !e.shiftKey &&
+        (e.key === "c" || e.key === "v" || e.key === "x" || e.key === "a")
+      ) {
+        return;
+      }
+
       // CMD+, — toggle settings panel (no altKey / shiftKey required)
       if (e.key === "," && !e.altKey && !e.shiftKey) {
         e.preventDefault();


### PR DESCRIPTION
## Summary

CMD+C/V/X/A were being intercepted by the global `keydown` handler in `useKeyboardShortcuts.ts`. Added an explicit early-return guard that passes standard clipboard shortcuts through to the browser default behavior.

The guard checks `!e.altKey && !e.shiftKey` to avoid blocking exotic combos like CMD+Shift+C that aren't clipboard operations.

## Test plan

- [ ] CMD+C copies selected text in note cards
- [ ] CMD+V pastes text
- [ ] CMD+X cuts text
- [ ] CMD+A selects all text in focused card
- [ ] CMD+D (split), CMD+W (close), CMD+T (new tab) still work
- [ ] CMD+Opt+* (panel navigation) still works
- [ ] TypeScript check clean, 98/98 tests pass

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/192?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->