### PR TITLE
fix(iframeProtocol): add missing fs commands to capability map (#187)

### DIFF
--- a/src/lib/iframeProtocol.ts
+++ b/src/lib/iframeProtocol.ts
@@ -54,8 +54,10 @@ export const COMMAND_CAPABILITY_MAP: Record<string, string> = {
   "plugin:fs|read_file": "fs:read",
   "plugin:fs|read_text_file": "fs:read",
   "plugin:fs|read_dir": "fs:read",
+  "plugin:fs|exists": "fs:read",
   "plugin:fs|write_file": "fs:write",
   "plugin:fs|write_text_file": "fs:write",
+  "plugin:fs|mkdir": "fs:write",
   // tauri-plugin-dialog
   "plugin:dialog|open": "dialog:open",
   "plugin:dialog|save": "dialog:save",


### PR DESCRIPTION
## Summary

Bundled plugins (`com.origin.filetree`, `com.origin.browser`, `com.origin.notepad`) call `plugin:fs|exists` and `plugin:fs|mkdir` but these were missing from `COMMAND_CAPABILITY_MAP` in `iframeProtocol.ts`, causing "Command not allowed" rejections at runtime.

Added:
- `plugin:fs|exists` → `fs:read` (read-only path existence check)
- `plugin:fs|mkdir` → `fs:write` (directory creation)

Verified no other fs commands are missing by auditing all 6 non-Monaco plugin bundles.

## Test plan

- [ ] FileTree plugin can check path existence and create directories
- [ ] Browser and Notepad plugins work without capability errors
- [ ] Unknown commands are still denied
- [ ] TypeScript check clean, 98/98 tests pass

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/193?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->