### PR TITLE
fix(plugins): use semver comparison in bundled plugin seeding (#189)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2523,6 +2523,7 @@ version = "0.2.0"
 dependencies = [
  "fix-path-env",
  "portable-pty",
+ "semver",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri-plugin-updater = "2"
 tokio = { version = "1", features = ["process", "sync"] }
 portable-pty = { version = "0.9", features = ["serde_support"] }
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
+semver = "1"
 
 [profile.release]
 panic = "abort"

--- a/src-tauri/src/commands/plugins.rs
+++ b/src-tauri/src/commands/plugins.rs
@@ -152,10 +152,30 @@ pub async fn seed_bundled_plugins(app: tauri::AppHandle) -> Result<Vec<String>, 
                 if let Ok(dest_manifest) =
                     serde_json::from_str::<MinimalManifest>(&dest_manifest_str)
                 {
-                    // Simple lexicographic semver compare — acceptable for single-digit
-                    // minor/patch versions (e.g. "0.1.0" < "0.2.0").
-                    if dest_manifest.version >= src_manifest.version {
-                        continue; // Installed version is same or newer; skip.
+                    // Use semver comparison so that multi-digit components compare
+                    // correctly (e.g. "0.10.0" > "0.9.0").  If either version string
+                    // is invalid we cannot be sure the installed copy is current, so
+                    // we fall through and re-seed rather than silently doing nothing.
+                    match (
+                        semver::Version::parse(&dest_manifest.version),
+                        semver::Version::parse(&src_manifest.version),
+                    ) {
+                        (Ok(installed), Ok(bundled)) => {
+                            if installed >= bundled {
+                                continue; // Installed version is same or newer; skip.
+                            }
+                        }
+                        _ => {
+                            // One or both version strings is not valid semver.
+                            // Log a warning and fall through to re-seed.
+                            eprintln!(
+                                "[seed_bundled_plugins] WARNING: unparseable version for \
+                                 plugin '{}' (installed={:?}, bundled={:?}); re-seeding.",
+                                src_manifest.id,
+                                dest_manifest.version,
+                                src_manifest.version,
+                            );
+                        }
                     }
                 }
             }
@@ -208,4 +228,86 @@ pub fn save_plugin_bundle(
         .map_err(|e| format!("Failed to write index.js: {e}"))?;
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for semver comparison logic used in seed_bundled_plugins
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    /// Helper that mirrors the comparison logic in `seed_bundled_plugins`:
+    /// returns `true` when the installed version is considered current (i.e.
+    /// we should *skip* re-seeding), `false` when we should seed, and `None`
+    /// when either string is invalid semver.
+    fn should_skip(installed: &str, bundled: &str) -> Option<bool> {
+        match (
+            semver::Version::parse(installed),
+            semver::Version::parse(bundled),
+        ) {
+            (Ok(inst), Ok(bund)) => Some(inst >= bund),
+            _ => None,
+        }
+    }
+
+    // --- basic ordering ---
+
+    #[test]
+    fn same_version_skips() {
+        assert_eq!(should_skip("1.0.0", "1.0.0"), Some(true));
+    }
+
+    #[test]
+    fn older_installed_seeds() {
+        assert_eq!(should_skip("0.1.0", "0.2.0"), Some(false));
+    }
+
+    #[test]
+    fn newer_installed_skips() {
+        assert_eq!(should_skip("0.3.0", "0.2.0"), Some(true));
+    }
+
+    // --- multi-digit components (the bug this fix addresses) ---
+
+    #[test]
+    fn multi_digit_minor_bundled_newer_seeds() {
+        // "0.10.0" > "0.9.0" semantically; lexicographic order gives the wrong answer.
+        assert_eq!(should_skip("0.9.0", "0.10.0"), Some(false));
+    }
+
+    #[test]
+    fn multi_digit_minor_installed_newer_skips() {
+        assert_eq!(should_skip("0.10.0", "0.9.0"), Some(true));
+    }
+
+    #[test]
+    fn multi_digit_patch_bundled_newer_seeds() {
+        assert_eq!(should_skip("1.0.9", "1.0.10"), Some(false));
+    }
+
+    #[test]
+    fn multi_digit_patch_installed_newer_skips() {
+        assert_eq!(should_skip("1.0.10", "1.0.9"), Some(true));
+    }
+
+    #[test]
+    fn multi_digit_major_bundled_newer_seeds() {
+        assert_eq!(should_skip("9.0.0", "10.0.0"), Some(false));
+    }
+
+    // --- invalid version strings fall back to re-seed (None) ---
+
+    #[test]
+    fn invalid_installed_version_returns_none() {
+        assert_eq!(should_skip("not-semver", "1.0.0"), None);
+    }
+
+    #[test]
+    fn invalid_bundled_version_returns_none() {
+        assert_eq!(should_skip("1.0.0", "bad"), None);
+    }
+
+    #[test]
+    fn both_invalid_returns_none() {
+        assert_eq!(should_skip("???", "!!!"), None);
+    }
 }


### PR DESCRIPTION
## Summary

`seed_bundled_plugins` compared version strings lexicographically, which is wrong for semver. Example: `"0.9.0" >= "0.10.0"` evaluates to `true` lexicographically (because `'9' > '1'`), causing downgrades when the installed version has a multi-digit minor/patch.

### Changes
- Added `semver = "1"` crate dependency
- Replaced string `>=` with `semver::Version::parse()` + semantic comparison
- Invalid version strings log a warning and fall through to re-seed (safe default)
- 11 new unit tests covering edge cases

## Test plan

- [ ] Plugin with installed `0.10.0` is not downgraded by bundled `0.9.0`
- [ ] Plugin with installed `0.8.0` is upgraded by bundled `0.9.0`
- [ ] Same version is not re-seeded
- [ ] Invalid version strings trigger re-seed with warning
- [ ] `cargo check` clean, 11/11 tests pass

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/195?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->