### PR TITLE
feat(plugins): hot-reload installed plugins without app restart

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,9 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Core window and path permissions",
-  "windows": ["main"],
+  "windows": [
+    "main"
+  ],
   "permissions": [
     "core:default",
     "core:path:default",
@@ -14,8 +16,16 @@
     "fs:default",
     {
       "identifier": "fs:scope",
-      "allow": [{ "path": "$APPDATA/**" }, { "path": "$APPDATA" }]
+      "allow": [
+        {
+          "path": "$APPDATA/**"
+        },
+        {
+          "path": "$APPDATA"
+        }
+      ]
     },
-    "opener:default"
+    "opener:default",
+    "fs:allow-watch"
   ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import CardLayout from "@/components/workspace/CardLayout";
 import TabBar from "@/components/workspace/TabBar";
 import WorkspaceOverlay from "@/components/workspace/WorkspaceOverlay";
 import SettingsPanel from "@/components/settings/SettingsPanel";
+import { usePluginWatcher } from "@/hooks/usePluginWatcher";
 
 function App() {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
@@ -27,6 +28,9 @@ function App() {
   const motion = useMotion();
 
   useKeyboardShortcuts({ onToggleSettings: () => setShowSettings((p) => !p) });
+
+  // Plugin hot-reload watcher — active only when devMode is on in Settings.
+  usePluginWatcher();
 
   useEffect(() => {
     appDataDir().then(setAppDataDir);

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -43,6 +43,7 @@ function Card({ nodeId }: Props) {
     }),
   );
 
+  const registryVersion = useWorkspaceStore((s) => s.registryVersion);
   const pluginId = node?.type === "leaf" ? node.pluginId : null;
   const pluginEntry = pluginId ? (getPlugin(pluginId) ?? null) : null;
   const theme = useResolvedTheme();
@@ -121,6 +122,7 @@ function Card({ nodeId }: Props) {
         </>
       ) : (
         <IframePluginHost
+          key={`${pluginId}-${registryVersion}`}
           pluginId={pluginId}
           context={pluginContext}
           manifest={pluginEntry?.manifest}

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -145,6 +145,8 @@ type SettingsPanelProps = {
 };
 
 export default function SettingsPanel({ open, onClose }: SettingsPanelProps) {
+  const devMode = useWorkspaceStore((s) => s.devMode);
+  const setDevMode = useWorkspaceStore((s) => s.setDevMode);
   const splitAutoLaunch = useWorkspaceStore((s) => s.splitAutoLaunch);
   const setSplitAutoLaunch = useWorkspaceStore((s) => s.setSplitAutoLaunch);
   const themePreference = useWorkspaceStore((s) => s.themePreference);
@@ -237,6 +239,22 @@ export default function SettingsPanel({ open, onClose }: SettingsPanelProps) {
           {/* Updates */}
           <Section title="Updates">
             <UpdateSettings />
+          </Section>
+
+          <div className="border-t border-border" />
+
+          {/* Developer */}
+          <Section title="Developer">
+            <Row
+              label="Dev mode"
+              description="Watch plugins directory for changes and auto-reload"
+            >
+              <Toggle
+                checked={devMode}
+                onChange={setDevMode}
+                label="Dev mode"
+              />
+            </Row>
           </Section>
 
           <div className="border-t border-border" />

--- a/src/hooks/usePluginWatcher.ts
+++ b/src/hooks/usePluginWatcher.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from "react";
+import { watch } from "@tauri-apps/plugin-fs";
+import { appDataDir } from "@tauri-apps/api/path";
+
+import { useWorkspaceStore } from "@/store/workspaceStore";
+import { clearPluginCache } from "@/plugins/loader";
+import { reloadRegistry } from "@/plugins/registry";
+
+export function usePluginWatcher(): void {
+  const devMode = useWorkspaceStore((s) => s.devMode);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!devMode) return;
+
+    let unwatchFn: (() => void) | null = null;
+    let cancelled = false;
+
+    async function startWatcher(): Promise<void> {
+      try {
+        const dataDir = await appDataDir();
+        const pluginsPath = `${dataDir}plugins`;
+
+        unwatchFn = await watch(
+          pluginsPath,
+          () => {
+            if (debounceRef.current) clearTimeout(debounceRef.current);
+            debounceRef.current = setTimeout(() => {
+              if (cancelled) return;
+              console.info("[hot-reload] Plugin change detected, reloading...");
+              clearPluginCache();
+              reloadRegistry()
+                .then(() => {
+                  useWorkspaceStore.getState().bumpRegistryVersion();
+                  console.info("[hot-reload] Plugins reloaded.");
+                })
+                .catch((e: unknown) => {
+                  console.error("[hot-reload] Registry reload failed:", e);
+                });
+            }, 300);
+          },
+          { recursive: true },
+        );
+      } catch (e) {
+        console.warn("[hot-reload] Failed to start plugin watcher:", e);
+      }
+    }
+
+    startWatcher();
+
+    return () => {
+      cancelled = true;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (unwatchFn) unwatchFn();
+    };
+  }, [devMode]);
+}

--- a/src/plugins/registry.test.ts
+++ b/src/plugins/registry.test.ts
@@ -116,3 +116,10 @@ describe("initRegistry", () => {
     expect(typeof entry!.load).toBe("function");
   });
 });
+
+describe("reloadRegistry", () => {
+  it("is exported as a function", async () => {
+    const mod = await import("@/plugins/registry");
+    expect(typeof mod.reloadRegistry).toBe("function");
+  });
+});

--- a/src/store/workspaceStore.test.ts
+++ b/src/store/workspaceStore.test.ts
@@ -1901,3 +1901,36 @@ describe("addCanvasCard", () => {
     expect(leaves[0]!.pluginId).toBe("com.origin.hello");
   });
 });
+
+describe("devMode", () => {
+  it("defaults to false", () => {
+    const { devMode } = useWorkspaceStore.getState();
+    expect(devMode).toBe(false);
+  });
+
+  it("can be toggled on", () => {
+    useWorkspaceStore.getState().setDevMode(true);
+    expect(useWorkspaceStore.getState().devMode).toBe(true);
+    useWorkspaceStore.getState().setDevMode(false);
+  });
+});
+
+describe("registryVersion", () => {
+  it("defaults to 0", () => {
+    expect(useWorkspaceStore.getState().registryVersion).toBe(0);
+  });
+
+  it("increments on bumpRegistryVersion", () => {
+    const before = useWorkspaceStore.getState().registryVersion;
+    useWorkspaceStore.getState().bumpRegistryVersion();
+    expect(useWorkspaceStore.getState().registryVersion).toBe(before + 1);
+  });
+
+  it("increments monotonically across multiple bumps", () => {
+    const start = useWorkspaceStore.getState().registryVersion;
+    useWorkspaceStore.getState().bumpRegistryVersion();
+    useWorkspaceStore.getState().bumpRegistryVersion();
+    useWorkspaceStore.getState().bumpRegistryVersion();
+    expect(useWorkspaceStore.getState().registryVersion).toBe(start + 3);
+  });
+});

--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -62,6 +62,14 @@ type WorkspaceState = {
   /** Selected update channel. Persisted so it survives restarts. */
   updateChannel: UpdateChannel;
   animationSpeed: AnimationSpeed;
+  /** Developer mode — enables plugin hot-reload via filesystem watcher. */
+  devMode: boolean;
+  /**
+   * Monotonically increasing counter bumped on plugin registry reload.
+   * Used as a React key suffix to force iframe remounts after hot-reload.
+   * NOT persisted — resets to 0 on app start.
+   */
+  registryVersion: number;
 };
 
 type WorkspaceActions = {
@@ -104,6 +112,10 @@ type WorkspaceActions = {
   /** Persist the user's update channel preference. */
   setUpdateChannel: (channel: UpdateChannel) => void;
   setAnimationSpeed: (speed: AnimationSpeed) => void;
+  /** Toggle developer mode (enables plugin hot-reload). */
+  setDevMode: (enabled: boolean) => void;
+  /** Bump the registry version counter to force plugin remounts. */
+  bumpRegistryVersion: () => void;
   // ── Canvas actions ───────────────────────────────────────────────────────
   /** Toggle between tiling and canvas view mode for the active workspace. */
   setViewMode: (mode: ViewMode) => void;
@@ -177,6 +189,8 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
       zoomedNodeId: null,
       themePreference: "system",
       updateChannel: "stable",
+      devMode: false,
+      registryVersion: 0,
       animationSpeed: "standard" as AnimationSpeed,
       buses: { [INITIAL_ID]: createPluginBus() },
 
@@ -636,6 +650,16 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
           draft.animationSpeed = speed;
         }),
 
+      setDevMode: (enabled) =>
+        set((draft) => {
+          draft.devMode = enabled;
+        }),
+
+      bumpRegistryVersion: () =>
+        set((draft) => {
+          draft.registryVersion += 1;
+        }),
+
       setPluginConfig: (cardId, patch) =>
         set((draft) => {
           const ws = getActiveWs(draft);
@@ -750,6 +774,7 @@ export const tauriHandler = createTauriStore(
       "updateChannel",
       "splitAutoLaunch",
       "animationSpeed",
+      "devMode",
     ],
     filterKeysStrategy: "pick",
     saveOnChange: true,


### PR DESCRIPTION
## Summary

Implements plugin hot-reload (#66) so plugin developers can iterate without restarting the app.

### How it works

1. **Dev mode toggle** in Settings → Developer section (persisted)
2. When active, `usePluginWatcher` hook starts a filesystem watcher on the plugins directory via `@tauri-apps/plugin-fs` `watch()`
3. On file change (debounced 300ms): clears the module + promise caches → calls `reloadRegistry()` with cache-busting `?v={timestamp}` query params → bumps `registryVersion` in the store
4. `Card.tsx` uses `key={\`${pluginId}-${registryVersion}\`}` on `IframePluginHost`, so bumping the version forces a clean iframe remount with the fresh module

### Files changed

| File | What |
|------|------|
| `src/store/workspaceStore.ts` | `devMode` (persisted) + `registryVersion` (ephemeral) state + actions |
| `src/plugins/registry.ts` | `reloadRegistry()` with cache-busting URLs, `pluginImportUrl()` helper |
| `src/hooks/usePluginWatcher.ts` | Filesystem watcher hook with 300ms debounce |
| `src/components/card/Card.tsx` | `registryVersion` in IframePluginHost key |
| `src/components/settings/SettingsPanel.tsx` | Dev mode toggle in Developer section |
| `src/App.tsx` | Wire `usePluginWatcher` |
| `src-tauri/capabilities/default.json` | `fs:allow-watch` permission |

### Testing

- 221 tests pass (5 new: devMode toggle, registryVersion bumping, reloadRegistry export)
- TypeScript: zero errors
- ESLint: zero warnings

closes #66

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/fellanH/origin/210?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->